### PR TITLE
Fix scope entry error

### DIFF
--- a/dist/gitb
+++ b/dist/gitb
@@ -3384,15 +3384,20 @@ function detect_scopes_from_staged_files {
                     if [ -n "$component" ]; then
                         if [ $i -eq $((${#path_components[@]} - 1)) ]; then
                             component_no_ext="${component%.*}"
+                            if [ -z "$component_no_ext" ]; then
+                                component_no_ext="$component"
+                            fi
                             component_no_ext_lower="${component_no_ext,,}"
-                            scope_counts["$component_no_ext_lower"]=$((${scope_counts["$component_no_ext_lower"]:-0} + 1))
-                            current_depth=$((i + 1))
-                            if [ -z "${scope_depths["$component_no_ext_lower"]}" ] || [ $current_depth -lt ${scope_depths["$component_no_ext_lower"]} ]; then
-                                scope_depths["$component_no_ext_lower"]=$current_depth
+                            if [ -n "$component_no_ext_lower" ]; then
+                                scope_counts["$component_no_ext_lower"]=$((${scope_counts["$component_no_ext_lower"]:-0} + 1))
+                                current_depth=$((i + 1))
+                                if [ -z "${scope_depths["$component_no_ext_lower"]}" ] || [ $current_depth -lt ${scope_depths["$component_no_ext_lower"]} ]; then
+                                    scope_depths["$component_no_ext_lower"]=$current_depth
+                                fi
                             fi
                         else
                             component_lower="${component,,}"
-                            if [[ ! "$component_lower" =~ ^(src|lib|test|tests|spec|specs|build|dist|node_modules|vendor|tmp|temp|cache|logs|log)$ ]]; then
+                            if [ -n "$component_lower" ] && [[ ! "$component_lower" =~ ^(src|lib|test|tests|spec|specs|build|dist|node_modules|vendor|tmp|temp|cache|logs|log)$ ]]; then
                                 scope_counts["$component_lower"]=$((${scope_counts["$component_lower"]:-0} + 1))
                                 current_depth=$((i + 1))
                                 if [ -z "${scope_depths["$component_lower"]}" ] || [ $current_depth -lt ${scope_depths["$component_lower"]} ]; then


### PR DESCRIPTION
…cript errors

When staged files include dotfiles (e.g., .gitignore, .env), the extension removal pattern ${component%.*} results in an empty string, causing bash "bad array subscript" errors. This fix:
- Uses the full filename when extension removal yields empty string
- Adds defensive checks before using variables as array subscripts