### PR TITLE
fix(ai): prevent sed illegal byte sequence on non-ASCII diffs

### DIFF
--- a/scripts/ai.sh
+++ b/scripts/ai.sh
@@ -273,7 +273,9 @@ function call_openrouter_api {
     fi
     
     # Escape special characters in prompt for JSON
-    local escaped_prompt=$(echo "$prompt" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | tr '\n' ' ' | sed 's/  */ /g')
+    # LC_ALL=C avoids "illegal byte sequence" errors from BSD sed on macOS when the
+    # prompt contains non-UTF-8-validatable bytes (e.g. Russian or other non-ASCII content in diffs).
+    local escaped_prompt=$(echo "$prompt" | LC_ALL=C sed 's/\\/\\\\/g' | LC_ALL=C sed 's/"/\\"/g' | tr '\n' ' ' | LC_ALL=C sed 's/  */ /g')
 
     # Select OpenRouter model (OpenAI-compatible)
     local model=$(get_ai_model)
@@ -512,7 +514,7 @@ function call_openrouter_api {
         ai_response=$(echo "$response" | LC_ALL=C sed -n 's/.*"choices"[[:space:]]*:[[:space:]]*\[.*"message"[[:space:]]*:[[:space:]]*{[[:space:]]*"role"[[:space:]]*:[[:space:]]*"assistant"[[:space:]]*,[[:space:]]*"content"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
         # Clean up escaped characters
         if [ -n "$ai_response" ]; then
-            ai_response=$(echo "$ai_response" | sed 's/\\n/\n/g' | sed 's/\\"/"/g' | sed 's/\\\\/\\/g')
+            ai_response=$(echo "$ai_response" | LC_ALL=C sed 's/\\n/\n/g' | LC_ALL=C sed 's/\\"/"/g' | LC_ALL=C sed 's/\\\\/\\/g')
         fi
     fi
     

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -205,7 +205,8 @@ function handle_ai_commit_generation {
     fi
     
     # Clean up the AI response (remove quotes, trim)
-    ai_commit_message=$(echo "$ai_commit_message" | sed 's/^"//;s/"$//' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    # LC_ALL=C avoids "illegal byte sequence" errors from BSD sed when the AI response contains non-ASCII characters.
+    ai_commit_message=$(echo "$ai_commit_message" | LC_ALL=C sed 's/^"//;s/"$//' | LC_ALL=C sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
     
     echo
     echo -e "${GREEN}AI generated commit message:${ENDCOLOR}"


### PR DESCRIPTION
## Summary

`gitb c aifp` failed with `sed: RE error: illegal byte sequence` and a "Failed to parse AI response" / empty raw response when the staged diff contained non-ASCII content (e.g. Russian markdown, JSON with Cyrillic strings).

Root cause: BSD sed on macOS validates input against the current locale (typically UTF-8). When the prompt — which embeds the diff — contains bytes that don't form valid UTF-8 sequences (or when sed walks a multibyte sequence at a buffer edge), it aborts the whole pipeline. Two sed invocations in the AI path were missing the `LC_ALL=C` guard that other sed calls in `ai.sh` already use:

- `scripts/ai.sh:276` — JSON-escaping the prompt (the actual failure point: it produced an empty `escaped_prompt`, which is why the screenshot shows an empty raw response)
- `scripts/ai.sh:515` — fallback unescaping of the AI response when `jq` isn't installed
- `scripts/commit.sh:208` — stripping quotes / trimming whitespace on the returned commit message (would fail symmetrically if the model returned non-ASCII text)

All three now run sed under `LC_ALL=C`, which treats input as raw bytes and matches the pattern already established at `ai.sh:406` and `ai.sh:512`.

## Test plan

- [ ] Run `gitb c aifp` on a branch with staged non-ASCII content (e.g. Russian `.md` files) on macOS — should generate and apply the AI commit message instead of erroring out
- [ ] Run `gitb c aifp` with ASCII-only changes — no regression
- [ ] Run `gitb c aifp` on a system without `jq` installed (forces the fallback sed parser at line 512–515)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J71KCGAnk16gmvbxmQfu4T)_