### PR TITLE
feat(commit): accept multi-word mode tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,23 @@ gitb hook create            # Set up project hooks
 
 ### `gitb commit <mode>`
 
+> **Tip — multi-word modes.** Any combination of commit modifiers can be written
+> as separate words in any order. The compact form and the multi-word form are
+> equivalent — they set the same flags:
+>
+> ```bash
+> gitb commit aifp           # compact
+> gitb commit ai fast push   # multi-word — same result
+> gitb commit push fast ai   # any order
+> gitb commit ai f p         # short aliases also work
+> ```
+>
+> Recognized modifier words: `ai` (`llm`, `i`), `fast` (`f`), `push` (`pu`, `p`),
+> `scope` (`s`), `msg` (`m`), `staged`, `fixup` (`fix`, `x`), `amend` (`am`,
+> `a`), `split` (`sp`, `sl`), `ticket` (`jira`, `j`, `t`), `last` (`l`),
+> `revert` (`rev`), `help` (`h`). The `ff`/`ffp` ultrafast modes remain
+> compact-only.
+
 | **Mode**   | **Short**    | **Description** | **Example Use Case** |
 |------------|--------------|-----------------|---------------------|
 | `<empty>`  |              | Select files to commit and create conventional message | Regular feature development |

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -69,8 +69,8 @@ fi
 
 ### Run script
 case "$1" in
-    commit|c|co|com)         
-        commit_script $2
+    commit|c|co|com)
+        commit_script "${@:2}"
     ;;
     push|p|ps|pus)         
         push_script $2

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -959,9 +959,38 @@ function after_commit {
 }
 
 
+### Map a single multi-word token to its commit flag(s).
+# Returns 1 for unknown tokens so the caller can surface a wrong_mode error.
+# Used only when commit_script receives 2+ arguments (multi-word form like
+# `gitb commit ai fast push`). Single-token compact forms (aifp, ffp, ...) are
+# still handled by the case statement below.
+function set_commit_flag_from_token {
+    case "$1" in
+        ai|llm|i)            llm="true";;
+        fast|f)              fast="true";;
+        push|pu|p)           push="true";;
+        scope|s)             scope="true";;
+        msg|m)               msg="true";;
+        ticket|jira|j|t)     ticket="true";;
+        staged)              staged="true";;
+        fixup|fix|x)         fixup="true";;
+        amend|am|a)          amend="true";;
+        split|sp|sl)         split="true";;
+        last|l)              last="true";;
+        revert|rev)          revert="true";;
+        help|h)              help="true";;
+        *) return 1;;
+    esac
+    return 0
+}
+
+
 ### Main function
-# $1: mode
+# $1...: mode token(s)
     # <empty> - regular commit mode
+    # Single token: compact form like aifp, ffp, llmsfp (see case below)
+    # Multiple tokens: any combination of words/aliases in any order, e.g.
+    #   `ai fast push`, `push fast ai`, `ai f p` all map to llm+fast+push
     # msg: use editor to write commit message
     # ticket: add ticket info to the end of message header
     # fast: fast commit with git add .
@@ -969,7 +998,7 @@ function after_commit {
     # push: push changes after commit
     # fastp: fast commit with push
     # fastsp: fast commit with scope and push
-    # fixup: fixup commit   
+    # fixup: fixup commit
     # fastfix: fixup commit with git add .
     # fastfixp: fast fixup commit with push
     # amend: add to the last without edit (add to last commit)
@@ -978,6 +1007,11 @@ function after_commit {
     # revert: revert commit
     # help: print help
 function commit_script {
+    if [ $# -ge 2 ]; then
+        for tok in "$@"; do
+            set_commit_flag_from_token "$tok" || wrong_mode "commit" "$tok"
+        done
+    else
     case "$1" in
         scope|s)            ;; # general commit with scope
         split|sp|sl)        split="true";; # force atomic-split flow (heuristic + manual messages)
@@ -1019,6 +1053,7 @@ function commit_script {
         *)
             wrong_mode "commit" $1
     esac
+    fi
 
 
     ### Print header


### PR DESCRIPTION
## Summary

- Treats 2+ args after `gitb commit` as space-separated modifiers, so `gitb commit ai fast push` is equivalent to `gitb commit aifp`.
- Modifier tokens accept the same aliases as the existing compact case statement (`ai`/`llm`/`i`, `fast`/`f`, `push`/`pu`/`p`, `scope`/`s`, `msg`/`m`, `staged`, `fixup`/`fix`/`x`, `amend`/`am`/`a`, `split`/`sp`/`sl`, `ticket`/`jira`/`j`/`t`, `last`/`l`, `revert`/`rev`, `help`/`h`).
- Order-independent — `ai fast push`, `push fast ai`, `ai f p` all set the same flags.
- Single-token compact forms (`aifp`, `ffp`, `llmsfp`, …) and the empty form (`gitb commit`) are unchanged.
- Out of scope per design: top-level `gitb ai fast push` (still requires a command), and the `ff`/`ffp` ultrafast `auto_accept` combo (compact-only).

## Implementation

- `scripts/base.sh` now forwards all trailing args: `commit_script "${@:2}"` (was `commit_script $2`).
- `scripts/commit.sh` adds a small helper `set_commit_flag_from_token` and a 2+ arg branch in `commit_script` that loops tokens through it, OR-ing flags. Unknown tokens surface via the existing `wrong_mode` helper.
- README adds a "multi-word modes" tip in the `gitb commit <mode>` section.

## Test plan

- [x] Unit-level smoke test: 16 cases covering compact regressions, multi-word equivalence, alias support, order-independence, unknown-token error, and empty-args fallthrough — all passing.
- [x] Dispatcher round-trip: confirmed `base.sh` forwards 0/1/N args correctly.
- [ ] Manual: run `gitb commit ai fast push` and `gitb commit aifp` against a scratch repo and confirm the printed `GIT COMMIT AI FAST & PUSH` header is identical.
- [ ] Manual: confirm `gitb commit ai fast bogus` reports `Unknown mode bogus for gitb commit`.

https://claude.ai/code/session_01TEbozpPkeLnvyDvpqUY98p

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEbozpPkeLnvyDvpqUY98p)_