### PR TITLE
docs(readme): cover all commands and adapt for top-repo discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# gitbasher – simple **bash** utility that makes **git** easy to use
-
+# gitbasher — make `git` fast, friendly, and forgettable
 
 [![Latest Release](https://img.shields.io/github/v/release/maxbolgarin/gitbasher.svg?style=flat-square)](https://github.com/maxbolgarin/gitbasher/releases/latest)
 [![GitHub license](https://img.shields.io/github/license/maxbolgarin/gitbasher.svg)](https://github.com/maxbolgarin/gitbasher/blob/master/LICENSE)
@@ -9,13 +8,26 @@
     <img src=".github/commit.gif" width="600" alt="commit example">
 </picture>
 
+**gitbasher** is a single-binary `bash` wrapper that turns the most common git operations into one short, interactive command. Stop memorizing flags. Stop pasting the same five commands in a row. Just type `gitb`.
+
+```bash
+gitb commit push       # stage, write a conventional commit, push — in one flow
+gitb c ai              # AI-generated commit message
+gitb sync              # fetch main + rebase your branch
+gitb wip               # snapshot WIP, push, keep moving
+gitb undo              # roll back your last commit / amend / merge / rebase / stash
+```
+
 ---
 
-With **gitbasher** usage of `git` becomes more simple and intuitive. It helps speeding up the development process, making it more consistent reducing mistakes. This is a wrapper around the most used git commands with a cleaner interface. It uses `bash` `git` `sed` `grep`, `curl` and some built-in utilities.
+## Install in 10 seconds
 
+**npm (easiest):**
+```bash
+npm install -g gitbasher
+```
 
-### Quick Installation (recommended)
-
+**Standalone binary (no Node required):**
 ```bash
 GITB_PATH=/usr/local/bin/gitb && \
 sudo mkdir -p $(dirname $GITB_PATH) && \
@@ -23,693 +35,589 @@ curl -fSL https://github.com/maxbolgarin/gitbasher/releases/latest/download/gitb
 sudo chmod +x $GITB_PATH
 ```
 
-Or using npm:
+> Windows users: run inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/setup/environment).
+> No `sudo`? Install to `~/.local/bin` and add it to `PATH`.
+
+**Requirements:** `bash` 4.0+, `git` 2.23+ (macOS: `brew install bash git`).
+
+---
+
+## 60-second quick start
 
 ```bash
-npm install -g gitbasher
+cd your-project
+gitb              # see all commands
+gitb cfg user     # set your name/email once
+gitb cfg ai       # (optional) plug in an AI key for smart commits
+
+gitb status       # what's changed?
+gitb commit       # interactive conventional commit
+gitb push         # safe push with conflict handling
+gitb pull         # smart pull (rebase / merge / ff)
+gitb branch new   # create a new conventionally-named branch
 ```
 
-In Windows use `wsl` (enter `wsl` in terminal, [read more](https://learn.microsoft.com/en-us/windows/wsl/setup/environment)) to enable Linux environment. Directory `/usr/local/bin/` is not mandatory. If you get `Permission denied`, use `sudo` or put it to `~/.local/bin` with adding it to `PATH` ([how](https://discussions.apple.com/thread/254226896)).
+Every command has a short alias (`gitb c`, `gitb p`, `gitb pu`, `gitb b`, `gitb st`, …) and a `help` mode (`gitb commit help`).
 
+---
 
-## Table of Contents
-- [Quick Start Guide](#quick-start-guide)
-- [Why You Should Try This](#why-you-should-try-this)
-- [Real-World Examples](#real-world-examples)
-- [AI-Powered Commits](#ai-powered-commits)
-- [Common Workflows](#common-workflows)
-- [Complete Documentation](#complete-documentation)
-- [Troubleshooting & FAQ](#troubleshooting--faq)
+## Table of contents
+- [Why gitbasher](#why-gitbasher)
+- [All features at a glance](#all-features-at-a-glance)
+- [AI-powered commits](#ai-powered-commits)
+- [Common workflows](#common-workflows)
+- [Command reference](#command-reference)
+  - [commit](#gitb-commit) · [push](#gitb-push) · [pull](#gitb-pull) · [branch](#gitb-branch) · [tag](#gitb-tag) · [merge](#gitb-merge) · [rebase](#gitb-rebase)
+  - [cherry](#gitb-cherry) · [sync](#gitb-sync) · [wip / unwip](#gitb-wip--unwip) · [fixup](#gitb-fixup) · [undo](#gitb-undo) · [reset](#gitb-reset) · [stash](#gitb-stash)
+  - [hook](#gitb-hook) · [config](#gitb-config) · [log](#gitb-log) · [info commands](#info-commands)
+- [Configuration](#configuration)
+- [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 
+---
 
-## Quick Start Guide
+## Why gitbasher
 
-### 1. First Steps
-```bash
-# Navigate to any git repository
-cd your-project
-
-# See all available commands
-gitb
-```
-
-### 2. Your First Commit
-```bash
-# Smart commit - select files and create conventional message
-gitb commit
-
-# Fast commit - add all files with quick message
-gitb commit fast
-
-# AI-powered commit (after setting up API key)
-gitb commit ai
-```
-
-### 3. Essential Daily Commands
-```bash
-gitb status        # Check status
-gitb commit        # Make a commit
-gitb push          # Push changes
-gitb pull          # Pull changes
-gitb branch        # Switch branches
-```
-
-### 4. Set Up Your Environment
-```bash
-# Configure your identity
-gitb cfg user
-
-# Set default branch (usually 'main' or 'master')
-gitb cfg default
-
-# Set up AI features (optional but recommended)
-gitb cfg ai
-```
-
-
-## Why You Should Try This
-
-**gitbasher** is essential if you use `git` on the daily basis. Benefits you will get:
-
-* **⚡ Faster Development**: Spend almost no time on git commands
-* **🧠 No More Memorizing**: No need to remember/google exact command names and parameters
-* **📝 Better Commit Messages**: Conventional commits with manual or **AI-generated** messages
-* **🔧 Advanced Commands Made Easy**: Use `git rebase`, `git stash`, and hooks without complexity
-* **🌊 GitHub Flow**: Simplified branch management following best practices
-* **🎯 Consistent Workflow**: Standardized processes across your team
+- **Zero memorization** — no flags to remember, no man pages to grep. Interactive menus where it matters, short aliases where it doesn't.
+- **Conventional commits, free** — type/scope/summary picker built-in, with optional ticket prefixes and multiline editor mode.
+- **AI commit messages** — `gitb c ai` writes the message for you (Gemini / Claude via OpenRouter, fully configurable).
+- **Atomic split** — `gitb c split` (or `aisplit`) breaks a messy working tree into one commit per logical scope.
+- **Safer git** — push/pull detect conflicts up front, `undo` rolls back commit/amend/merge/rebase/stash, `reset` is interactive.
+- **Whole workflows, not just commands** — `sync`, `wip`, `fixup`, `branch newd`, `merge to-main` chain the steps you'd otherwise do by hand.
+- **One file, no deps** — pure bash. Drop the binary anywhere on `PATH` and go.
+- **115+ tests** — BATS test suite covers sanitization, git ops, branch logic.
 
 <picture>
     <img src=".github/push.gif" width="600" alt="push example">
 </picture>
 
+---
 
-## Real-World Examples
+## All features at a glance
 
-### 🚀 Scenario 1: Starting a New Feature
+| Group | Commands | What you get |
+|-------|----------|--------------|
+| **Commit** | `commit` (`c`) | Interactive conventional commits, fast-mode, AI messages, atomic split, fixup, amend, last-message edit, revert |
+| **Sync remote** | `push` (`p`), `pull` (`pu`), `sync` (`sy`) | Safe push (with force/list), smart pull (rebase / merge / ff), one-shot rebase-on-main with optional force-push |
+| **Branches** | `branch` (`b`), `prev` (`-`) | List / switch / create-from-current / create-from-updated-main / delete (orphaned, merged, gone) / recent / previous / checkout-tag |
+| **Integration** | `merge` (`m`), `rebase` (`r`), `cherry` (`ch`) | Merge into current / into main / from remote · rebase onto main / interactive / autosquash / fastautosquash / pull-commits · cherry-pick by hash, range, or interactive |
+| **Tags & releases** | `tag` (`t`) | Lightweight, annotated, from-commit, push, push-all, delete, delete-all, list, fetch-remote |
+| **Save & rollback** | `wip` / `unwip`, `undo` (`un`), `reset` (`res`), `stash` (`s`), `fixup` (`fx`) | One-command WIP snapshot/restore · undo last commit/amend/merge/rebase/stash · interactive reset · full stash menu · fixup + autosquash in a single step |
+| **Inspect** | `status` (`st`), `log` (`l`), `reflog` (`rl`), `last-commit` (`lc`), `last-ref` (`lr`) | Pretty repo status, multi-mode log + search, reflog viewer, quick last-commit / last-ref summary |
+| **Hooks** | `hook` (`ho`) | List / create from templates / edit / toggle / remove / test / show — for every git hook |
+| **Config** | `config` (`cfg`) | User, default branch, separator, editor, ticket prefix, scopes, AI key, AI model, proxy |
 
-**Traditional Git:**
+Total: **23 top-level commands**, **60+ aliases**, **100+ modes**.
+
+---
+
+## AI-powered commits
+
+Drop in an API key once, then let Claude / Gemini write conventional commit messages from your diff.
+
+### Setup
+
 ```bash
-git switch main                   # Switch to main
-git pull origin main                # Get latest changes
-git switch -c feature/user-auth   # Create new branch
-# ... make changes ...
-git add src/auth.js src/login.js    # Stage files
-git commit -m "feat(auth): add user authentication system"
-git push -u origin feature/user-auth
-```
+# 1. Get a key (free tier available) at https://aistudio.google.com/app/apikey
+#    or use your OpenRouter key for Claude / multi-provider access.
+gitb cfg ai          # paste key — choose local repo or global
 
-**With gitbasher:**
-```bash
-gitb branch newd                   # Create new branch from updated main
-# ... make changes ...
-gitb commit push                    # Smart commit + push
-```
-
-### 🐛 Scenario 2: Quick Bug Fix
-
-**Traditional Git:**
-```bash
-git status                          # Check what's changed
-git add .                          # Add all files
-git commit -m "fix: resolve login issue"
-git push
-```
-
-**With gitbasher:**
-```bash
-gitb commit push                   # Fast commit + push (one command!)
-```
-
-### 🔀 Scenario 3: Merging Feature Branch
-
-**Traditional Git:**
-```bash
-git switch main
-git pull origin main
-git merge feature/user-auth
-git push origin main
-git branch -d feature/user-auth
-```
-
-**With gitbasher:**
-```bash
-gitb merge to-main             # Switch to main and merge current branch
-gitb branch delete                 # Select and delete the merged branch
-```
-
-### 🤖 Scenario 4: AI-Powered Development
-
-**After making changes to multiple files:**
-```bash
-gitb commit ai                   # AI analyzes changes and generates:
-                           # "feat(auth): implement JWT authentication with refresh tokens"
-```
-
-**For quick fixes:**
-```bash
-gitb commit aif                  # AI commit all files with smart message
-```
-
-### 🎯 Scenario 5: Code Review Preparation
-
-**Clean up commits before PR:**
-```bash
-gitb rebase i                    # Interactive rebase to squash/reorder commits
-gitb commit fix                  # Create fixup commits for review feedback
-gitb rebase s                    # Auto-squash fixup commits
-```
-
-### 📦 Scenario 6: Release Management
-
-**Creating and managing releases:**
-```bash
-gitb tag                      # Create version tag
-gitb tag push                 # Push tag to remote
-gitb log                      # Review commit history
-```
-
-
-## AI-Powered Commits
-
-Transform your commit workflow with AI-generated messages that follow conventional commit standards.
-
-### Setup (One-time)
-
-#### 1. Get Your API Key
-- Visit [Google AI Studio](https://aistudio.google.com/app/apikey)
-- Create a new API key
-- Copy it for the next step
-
-#### 2. Configure gitbasher
-```bash
-gitb cfg ai
-# Enter your API key when prompted
-# Choose local (current repo) or global (all repos)
-```
-
-#### 3. Optional: Proxy Setup
-For regions with API restrictions:
-```bash
+# 2. Optional: HTTP proxy (for restricted regions)
 gitb cfg proxy
-# Examples:
-# http://proxy.example.com:8080
-# http://username:password@proxy.example.com:8080
 ```
 
-### AI Command Examples
+### Commands
 
-| **Scenario** | **Command** | **What It Does** |
-|--------------|-------------|------------------|
-| **Staged files ready** | `gitb c ai` | Analyzes staged changes, generates message |
-| **Quick fix needed** | `gitb c aif` | Adds all files + AI message |
-| **Ready to ship** | `gitb c aip` | AI commit + automatic push |
-| **Full workflow** | `gitb c aifp` | Add all + AI commit + push |
-| **Need control** | `gitb c ais` | AI message + manual type/scope |
-| **Detailed commit** | `gitb c aim` | Generates multiline commit message |
-| **Hands-free**       | `gitb c ff`  | Stage everything, AI-grouped split, AI messages, no prompts |
+| Goal | Command | What it does |
+|------|---------|--------------|
+| Staged files ready | `gitb c ai` | AI message from staged diff |
+| Quick fix | `gitb c aif` | `git add .` + AI message |
+| Ship now | `gitb c aip` | AI message + push |
+| Full workflow | `gitb c aifp` | `add .` + AI + push |
+| Manual type/scope | `gitb c ais` | You pick type/scope, AI writes summary |
+| Detailed message | `gitb c aim` | Multiline subject + body |
+| Atomic split (AI) | `gitb c aisplit` | AI groups your diff into one commit per scope, writes each message |
+| Hands-free | `gitb c ff` / `ffp` | `add .` + AI-grouped split + AI messages, no prompts |
 
-### AI Models
+Modes are composable: `gitb c ai fast push` is identical to `gitb c aifp`.
 
-Each AI task uses a model picked for its speed / cost / quality balance. Defaults (May 2026):
+### Models
+
+Each task uses a model tuned for speed/cost/quality. Defaults (May 2026):
 
 | Task | Default model | Why |
 |------|---------------|-----|
-| `simple` (single-line message) | `google/gemini-3.1-flash-lite-preview` | Cheapest fast tier; 2.5x faster TTFT than 2.5 Flash |
-| `subject` (subject after manual type/scope) | `google/gemini-3.1-flash-lite-preview` | Same — short structured output |
-| `full` (header + body) | `google/gemini-3-flash-preview` | Better body prose (+15% accuracy vs 2.5 Flash) |
-| `grouping` (atomic-split scope→file mapping) | `anthropic/claude-haiku-4.5` | Strict instruction following for the validated TSV output |
+| `simple` (one-line message) | `google/gemini-3.1-flash-lite-preview` | Cheapest fast tier |
+| `subject` (after manual type/scope) | `google/gemini-3.1-flash-lite-preview` | Short structured output |
+| `full` (header + body) | `google/gemini-3-flash-preview` | Better prose |
+| `grouping` (atomic-split mapping) | `anthropic/claude-haiku-4.5` | Strict instruction following |
 
-Override per task via git config (no UI needed):
+Override per task or globally:
 ```bash
-git config gitbasher.ai-model-simple   <model_id>
-git config gitbasher.ai-model-subject  <model_id>
-git config gitbasher.ai-model-full     <model_id>
-git config gitbasher.ai-model-grouping <model_id>
+gitb cfg model                                          # interactive
+git config gitbasher.ai-model            <model_id>     # global
+git config gitbasher.ai-model-simple     <model_id>     # per-task
+git config gitbasher.ai-model-subject    <model_id>
+git config gitbasher.ai-model-full       <model_id>
+git config gitbasher.ai-model-grouping   <model_id>
 ```
 
-Or set a single global override that applies to every task:
+---
+
+## Common workflows
+
+### Daily development
 ```bash
-gitb cfg model      # interactive
-# or
-git config gitbasher.ai-model <model_id>
+gitb st              # status
+gitb pu              # pull
+gitb b n             # new feature branch
+# ... code ...
+gitb c ai            # AI commit
+gitb p               # push
 ```
 
-Some Gemini 3.x defaults are preview slugs; they'll be updated when Google promotes them to GA.
-
-## Common Workflows
-
-### 🔄 Daily Development Workflow
-
+### Start a new feature
 ```bash
-# Start your day
-gitb st                     # Check repository status
-gitb pu                     # Pull latest changes
-
-# Work on features
-gitb b n                    # Create new feature branch
-# ... code changes ...
-gitb c ai                   # AI-powered commit
-gitb p                      # Push changes
-
-# Code review cycle
-gitb c fix                  # Create fixup commits
-gitb r a                    # Clean up with autosquash
-gitb p f                    # Force push cleaned history
+gitb b nd            # branch newd: switch to main, pull, branch off
+# ... code ...
+gitb c push          # commit + push
 ```
 
-### 🚨 Hotfix Workflow
-
+### Code-review cycle
 ```bash
-gitb b main                 # Switch to main branch
-gitb pu                     # Get latest changes
-gitb b n                    # Create hotfix branch
-# ... fix the issue ...
-gitb c aif                  # Fast AI commit
-gitb p                      # Push hotfix
-gitb m to-main             # Merge to main
+gitb c fix           # fixup commit for review feedback
+gitb r a             # autosquash fixups
+gitb p f             # force-push cleaned history
+# — or in one step —
+gitb fx fastp        # add all + fixup + autosquash + force-push
 ```
 
-### 🔀 Feature Integration
-
+### Sync with main mid-feature
 ```bash
-# Prepare feature for merge
-gitb pu                     # Update current branch
-gitb r main                 # Rebase on main
-gitb l                      # Review commit history
-gitb c fix                  # Address review feedback
-gitb r a                    # Squash fixups
-
-# Integrate
-gitb m to-main             # Merge to main
-gitb b del                 # Clean up feature branch
+gitb sync            # fetch main + rebase your branch
+gitb sync push       # …and force-push
+gitb sync merge      # use merge instead of rebase
 ```
 
-### 🎯 Release Workflow
-
+### Save WIP across machines / branches
 ```bash
-gitb b main                 # Switch to main
-gitb pu                     # Get latest changes
-gitb l                      # Review changes since last release
-gitb t a                    # Create annotated release tag
-gitb t push                 # Push tag to trigger CI/CD
+gitb wip             # add . + WIP commit + push
+# … on another machine …
+gitb pu && gitb unwip   # restore changes, drop the WIP commit
 ```
 
-### 🛠️ Maintenance Workflow
-
+### Hotfix
 ```bash
-# Clean up old branches
-gitb b del                  # Interactive branch deletion
-
-# Manage stashes
-gitb stash                  # Interactive stash management
-
-# Check hooks
-gitb hook list              # See all git hooks status
-gitb hook create            # Set up project hooks
+gitb b m             # switch to main
+gitb pu              # latest changes
+gitb b n             # hotfix branch
+gitb c aifp          # fast AI commit + push
+gitb m tm            # merge to main
 ```
 
-
-## Complete Documentation
-
-### Available Commands
-
-| Command                         | Short aliases       | Description                              |
-|---------------------------------|---------------------|------------------------------------------|
-| [**commit**](#gitb-commit-mode) | `c` `co` `com`    | Everything about commit creation         |
-| [**push**](#gitb-push-mode)     | `p` `ps` `ph`     | Pushing changes to a remote repository   |
-| [**pull**](#gitb-pull-mode)     | `pu` `pl` `pul`   | Pulling changes from a remote repository |
-| [**branch**](#gitb-branch-mode) | `b` `br` `bran`   | Managing branches                        |
-| [**tag**](#gitb-tag-mode)       | `t` `tg`           | Managing tags                            |
-| [**merge**](#gitb-merge-mode)   | `m` `me`           | Merge changes to the current branch      |
-| [**rebase**](#gitb-rebase-mode) | `r` `re` `base`   | Rebase current branch                    |
-| [**reset**](#gitb-reset-mode)   | `res`               | Easy to use git reset                    |
-| [**stash**](#gitb-stash-mode)   | `s` `sta`          | Manage git stashes                       |
-| [**hook**](#gitb-hook-mode)     | `ho` `hk`          | Comprehensive git hooks management with interactive menus |
-| [**config**](#gitb-config-mode) | `cf` `cfg` `conf` | Configurate gitbasher                    |
-| **status**                      | `st`                | Info about repo and changed files        |
-| [**log**](#gitb-log-mode)       | `l` `lg`           | Git log utilities and search functions   |
-| **reflog**                      | `rl` `rlg`         | Open git reflog in a pretty format       |
-| **help**                        | `h` `man`          | Show help                                |
-
-
-### `gitb commit <mode>`
-
-> **Tip — multi-word modes.** Any combination of commit modifiers can be written
-> as separate words in any order. The compact form and the multi-word form are
-> equivalent — they set the same flags:
->
-> ```bash
-> gitb commit aifp           # compact
-> gitb commit ai fast push   # multi-word — same result
-> gitb commit push fast ai   # any order
-> gitb commit ai f p         # short aliases also work
-> ```
->
-> Recognized modifier words: `ai` (`llm`, `i`), `fast` (`f`), `push` (`pu`, `p`),
-> `scope` (`s`), `msg` (`m`), `staged`, `fixup` (`fix`, `x`), `amend` (`am`,
-> `a`), `split` (`sp`, `sl`), `ticket` (`jira`, `j`, `t`), `last` (`l`),
-> `revert` (`rev`), `help` (`h`). The `ff`/`ffp` ultrafast modes remain
-> compact-only.
-
-| **Mode**   | **Short**    | **Description** | **Example Use Case** |
-|------------|--------------|-----------------|---------------------|
-| `<empty>`  |              | Select files to commit and create conventional message | Regular feature development |
-| `msg`      | `m`          | Create multiline commit message using text editor | Detailed commit descriptions |
-| `ticket`   | `t`          | Add tracker's ticket info to commit header | JIRA/GitHub issue integration |
-| `fast`     | `f`          | Add all files and create commit without scope | Quick bug fixes |
-| `fasts`    | `fs`         | Add all files and create commit with scope | Feature additions |
-| `push`     | `pu` `p`    | Create commit and push changes | Deploy-ready commits |
-| `fastp`    | `fp`         | Fast commit and push | One-command workflow |
-| `fastsp`   | `fsp` `fps` | Fast commit with scope and push | Complete feature deployment |
-| `split`    | `sp` `sl`   | Split staged changes into one commit per detected scope (heuristic grouping, manual type+summary per group) | Atomic commits without AI |
-| `splitp`   | `spp` `slp` | Same as split, then push the resulting commits | Atomic split with deploy |
-| `aisplit`  | `isplit` `aispl` `ispl`     | Same as split, but AI refines the grouping when heuristic is weak and writes each commit message | AI-driven atomic split |
-| `aisplitp` | `isplitp` `aisplp` `isplp`  | Same as aisplit, then push the resulting commits | AI atomic split with deploy |
-| `ff`       |             | Ultrafast: `git add .`, AI-grouped split, AI messages, no prompts (requires AI configured) | Hands-free commit on a clean branch |
-| `ffp`      | `ffpush`    | Same as ff, then push the resulting commits | Fully automated commit + push |
-| `ai`       | `llm` `i`   | AI-generated commit message | Smart commit automation |
-| `aif`      | `llmf` `if` | Fast AI commit without confirmation | Rapid development |
-| `aip`      | `llmp` `ip` | AI commit and push | AI-powered deployment |
-| `aifp`     | `llmfp` `ifp` | Fast AI commit with push | Complete AI workflow |
-| `ais`      | `llms` `is` | AI summary with manual type/scope | Controlled AI assistance |
-| `aim`      | `llmm` `im` | AI multiline commit message | Detailed AI documentation |
-| `fixup`    | `fix` `x`   | Create fixup commit for rebase | Code review fixes |
-| `fixupp`   | `fixp` `xp` | Fixup commit and push | Remote fixup commits |
-| `fastfix`  | `fx`         | Fast fixup all files | Quick fixup workflow |
-| `fastfixp` | `fxp`        | Fast fixup and push | Complete fixup deployment |
-| `amend`    | `am` `a`    | Add files to last commit | Forgot to include files |
-| `amendf`   | `amf` `af`  | Amend with all files | Complete last commit |
-| `last`     | `l`          | Change last commit message | Fix commit message typos |
-| `revert`   | `rev`        | Revert selected commit | Undo problematic changes |
-
-### `gitb push <mode>`
-
-| **Mode**  | **Short** | **Description** | **When to Use** |
-|-----------|-----------|-----------------|-----------------|
-| `<empty>` |           | Show commits and push with conflict handling | Regular push workflow |
-| `yes`     | `y`       | Push without confirmation | Automated scripts |
-| `force`   | `f`       | Force push (use with caution) | After rebase/amend |
-| `list`    | `log` `l` | Show unpushed commits only | Review before push |
-
-### `gitb pull <mode>`
-
-| **Mode**      | **Short**  | **Description** | **Best For** |
-|---------------|------------|-----------------|--------------|
-| `<empty>`     |            | Smart pull with strategy selection | Daily workflow |
-| `fetch`       | `fe`       | Fetch only, no merge | Review changes first |
-| `all`         | `fa`       | Fetch all branches | Sync repository |
-| `upd`         | `u`        | Update all remote references | Branch cleanup |
-| `ffonly`      | `ff`       | Fast-forward only merge | Linear history |
-| `merge`       | `m`        | Always create merge commit | Feature branches |
-| `rebase`      | `r`        | Rebase current branch | Clean history |
-| `interactive` | `ri` `rs` | Interactive rebase with autosquash | Commit cleanup |
-
-### `gitb branch <mode>`
-
-| **Mode**  | **Short**  | **Description** | **Use Case** |
-|-----------|------------|-----------------|--------------|
-| `<empty>` |            | Interactive branch selection | Switch branches |
-| `list`    | `l`        | Show local branches | Branch overview |
-| `remote`  | `re` `r`  | Switch to remote branch | Work on others' branches |
-| `main`    | `def` `m` | Quick switch to main | Back to main branch |
-| `new`     | `n` `c`   | Create branch from current | Feature from current state |
-| `newd`    | `nd`       | Create branch from updated main | New feature branch |
-| `delete`  | `del` `d` | Delete local branch | Cleanup merged branches |
-
-### `gitb tag <mode>`
-
-| **Mode**     | **Short**       | **Description** | **Perfect For** |
-|--------------|-----------------|---------------------------------------------------------|-----------------|
-| `<empty>`    |                 | Create new tag from last commit | Quick releases |
-| `annotated`  | `a` `an`       | Create annotated tag with message | Official releases |
-| `commit`     | `c` `co` `cm` | Create tag from selected commit | Retrospective tagging |
-| `all`        | `al`            | Create annotated tag from selected commit | Complex releases |
-| `push`       | `ps` `ph` `p` | Push local tag to remote | Deploy releases |
-| `push-all`   | `pa`            | Push all tags to remote | Sync all releases |
-| `delete`     | `del` `d`      | Delete local tag | Fix tag mistakes |
-| `delete-all` | `da`            | Delete all local tags | Clean slate |
-| `list`       | `log` `l`      | Show local tags | Review releases |
-| `remote`     | `fetch` `r`    | Fetch and show remote tags | Check remote releases |
-
-### `gitb merge <mode>`
-
-| **Mode**  | **Short** | **Description** | **When to Use** |
-|-----------|-----------|-----------------------------------------------------------------|--------------|
-| `<empty>` |           | Select branch to merge with conflict resolution | Feature integration |
-| `main`    | `m`       | Merge main into current branch | Update feature branch |
-| `to-main` | `tm`      | Switch to main and merge current branch | Complete feature |
-
-### `gitb rebase <mode>`
-
-| **Mode**      | **Short**           | **Description** | **Best For** |
-|---------------|---------------------|-------------------------------------------------------------------------------|--------------|
-| `<empty>`     |                     | Select base branch for rebase | Branch updates |
-| `main`        | `m`                 | Rebase current branch onto main | Linear history |
-| `interactive` | `i`                 | Interactive rebase from selected commit | History editing |
-| `autosquash`  | `a` `s` `f` `ia` | Interactive rebase with fixup commits | Clean commit history |
-
-### `gitb reset <mode>`
-
-| **Mode**      | **Short** | **Description** | **Use Case** |
-|---------------|-----------|-------------------------------------------------------------------------|--------------|
-| `<empty>`     |           | Reset last commit (mixed mode) | Undo last commit, keep changes |
-| `soft`        | `s`       | Soft reset last commit | Redo commit message |
-| `undo`        | `u`       | Undo last reset operation | Recover from mistake |
-| `interactive` | `i`       | Select commit to reset to | Go back multiple commits |
-| `ref`         | `r`       | Reset to selected HEAD reference | Use reflog recovery |
-
-### `gitb stash <mode>`
-
-| **Mode**     | **Short** | **Description** | **Perfect For** |
-|--------------|-----------|-----------------|-----------------|
-| `<empty>`    |           | Interactive stash menu | Explore all options |
-| `select`     | `sel`     | Stash specific files | Partial work saving |
-| `all`        |           | Stash everything including untracked | Complete state save |
-| `list`       | `l`       | View all stashes | Find specific stash |
-| `pop`        | `p`       | Apply and remove stash | Continue work |
-| `show`       | `s`       | Preview stash contents | Check before apply |
-| `apply`      | `a`       | Apply without removing | Keep stash backup |
-| `drop`       | `d`       | Delete stash | Cleanup unused stashes |
-
-### `gitb hook <mode>`
-
-| **Mode**     | **Short**       | **Description** | **Use Case** |
-|--------------|-----------------|-----------------|--------------|
-| `<empty>`    |                 | Interactive action menu | Explore all operations |
-| `list`       | `l`             | Show all hooks with status | Audit current setup |
-| `create`     | `new` `c`       | Create new hook with templates | Set up automation |
-| `edit`       | `e`             | Edit existing hook | Modify behavior |
-| `toggle`     | `t`             | Enable/disable hook | Temporary control |
-| `remove`     | `rm` `r`        | Delete hook(s) | Cleanup |
-| `test`       | `run` `check`   | Test hook execution | Verify functionality |
-| `show`       | `cat` `view` `s`| Display hook contents | Review implementation |
-
-### `gitb config <mode>`
-
-| **Mode**    | **Short**               | **Description** | **Example** |
-|-------------|-------------------------|-------------------------------------------------------------|-------------|
-| `<empty>`   |                         | Show current gitbasher configuration | Check setup |
-| `user`      | `u` `name` `email`    | Set user name and email | Initial setup |
-| `default`   | `def` `d` `b` `main` | Set default branch name | Project standards |
-| `separator` | `sep` `s`              | Set branch name separator | Naming conventions |
-| `editor`    | `ed` `e`               | Set commit message editor | Personal preference |
-| `ticket`    | `ti` `t` `jira`       | Set ticket prefix for commits/branches | Issue tracking |
-| `scopes`    | `sc` `s`               | Set common scopes for commits | Project structure |
-| `ai`        | `llm` `key`            | Configure AI API key | Smart commits |
-| `proxy`     | `prx` `p`              | Set HTTP proxy for AI requests | Geographic restrictions |
-| `delete`    | `unset` `del`          | Remove global configuration | Reset settings |
-
-### `gitb log <mode>`
-
-| **Mode**      | **Short**     | **Description** | **Great For** |
-|---------------|---------------|-----------------------------------------------------------------------|--------------|
-| `<empty>`     |               | Pretty git log for current branch | Review recent work |
-| `branch`      | `b`           | Select branch to view log | Compare branches |
-| `compare`     | `comp` `c`    | Compare logs between two branches | Merge preparation |
-| `search`      | `s`           | Search commits with various criteria | Find specific changes |
-
-#### Log Search Options
-
-| **Search Mode** | **Short** | **Description** | **Example Use** |
-|-----------------|-----------|-----------------------------------------------------------------------|--------------|
-| `message`       | `msg` `m` | Search by commit message | Find feature commits |
-| `author`        | `a`       | Search by author name/email | Team member contributions |
-| `file`          | `f`       | Search commits affecting specific files | File history |
-| `content`       | `pickaxe` `p` | Search by added/removed content | Code archaeology |
-| `date`          | `d`       | Search within date range | Release timeframes |
-| `hash`          | `commit` `h` | Search by commit hash pattern | Specific commit lookup |
-
-
-## Troubleshooting & FAQ
-
-### 📋 Common Issues & Solutions
-
-#### ❓ "Command not found: gitb"
+### Release
 ```bash
-# Check if gitb is installed
-which gitb
-
-# If not found, reinstall
-GITB_PATH=/usr/local/bin/gitb && \
-curl -SL https://github.com/maxbolgarin/gitbasher/releases/latest/download/gitb -o $GITB_PATH && \
-chmod +x $GITB_PATH
-
-# Alternative: Install to user directory
-mkdir -p ~/.local/bin
-GITB_PATH=~/.local/bin/gitb && \
-curl -SL https://github.com/maxbolgarin/gitbasher/releases/latest/download/gitb -o $GITB_PATH && \
-chmod +x $GITB_PATH
-# Add to PATH: echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+gitb b m
+gitb pu
+gitb l               # review log
+gitb t a             # annotated tag
+gitb t p             # push tag
 ```
 
-#### ❓ "Permission denied" when installing
+### Roll back a mistake
 ```bash
-# Use sudo for system-wide installation
-sudo curl -SL https://github.com/maxbolgarin/gitbasher/releases/latest/download/gitb -o /usr/local/bin/gitb
-sudo chmod +x /usr/local/bin/gitb
-
-# Or install to user directory (no sudo needed)
-mkdir -p ~/.local/bin
-curl -SL https://github.com/maxbolgarin/gitbasher/releases/latest/download/gitb -o ~/.local/bin/gitb
-chmod +x ~/.local/bin/gitb
+gitb undo            # undo last commit (keeps changes staged)
+gitb undo amend      # restore pre-amend state via reflog
+gitb undo merge      # abort or undo last merge
+gitb undo rebase     # abort or undo last rebase
+gitb undo stash      # re-stash a popped stash
 ```
 
-#### ❓ AI features not working
+### Branch hygiene
 ```bash
-# Check if API key is configured
-gitb cfg
-
-# Set up API key
-gitb cfg ai
-
-# Test with a simple commit
-echo "test" >> test.txt
-git add test.txt
-gitb c ai
-
-# If in restricted region, set up proxy
-gitb cfg proxy
-# Example: http://proxy.example.com:8080
+gitb b rc            # pick from recently used branches
+gitb b g             # delete local branches whose remote is gone
+gitb b del           # interactive delete (orphaned / merged / pick)
+gitb b -             # back to previous branch (like cd -)
 ```
 
-#### ❓ "Bad substitution" or bash errors
+---
+
+## Command reference
+
+> **Tip:** every command accepts `help` (`h`) for inline help: `gitb commit help`, `gitb sync h`.
+
+### Top-level commands
+
+| Command | Aliases | Description |
+|---------|---------|-------------|
+| [`commit`](#gitb-commit) | `c` `co` `com` | Create commits (interactive, fast, AI, split, fixup, amend, revert, …) |
+| [`push`](#gitb-push) | `p` `ps` `pus` | Push with conflict handling, force, or list-only |
+| [`pull`](#gitb-pull) | `pu` `pl` `pul` | Smart pull: rebase / merge / ff / fetch-only / interactive |
+| [`branch`](#gitb-branch) | `b` `br` `bran` | Switch / list / create / delete / recent / gone / checkout-tag |
+| [`tag`](#gitb-tag) | `t` `tg` | Create, push, list, delete tags (lightweight & annotated) |
+| [`merge`](#gitb-merge) | `m` `me` | Merge into current, into main, or from remote |
+| [`rebase`](#gitb-rebase) | `r` `re` `base` | Rebase onto main / interactive / autosquash / pull-commits |
+| [`cherry`](#gitb-cherry) | `ch` `cp` | Cherry-pick by hash, range, or interactive picker |
+| [`sync`](#gitb-sync) | `sy` | Fetch main + rebase (or merge) current branch, optional push |
+| [`wip`](#gitb-wip--unwip) | `w` | Stage all + WIP commit + push (one keystroke save) |
+| [`unwip`](#gitb-wip--unwip) | `uw` | Undo a WIP commit and restore the changes |
+| [`fixup`](#gitb-fixup) | `fx` | Create fixup commit and autosquash in one step |
+| [`undo`](#gitb-undo) | `un` | Undo last commit / amend / merge / rebase / stash |
+| [`reset`](#gitb-reset) | `res` | Friendly `git reset` with undo support |
+| [`stash`](#gitb-stash) | `s` `sta` | Full stash menu: select, all, list, pop, apply, show, drop |
+| [`hook`](#gitb-hook) | `ho` `hk` | Manage git hooks: list, create, edit, toggle, remove, test, show |
+| [`config`](#gitb-config) | `cf` `cfg` `conf` | Configure user, branch, AI, scopes, ticket prefix, etc. |
+| [`log`](#gitb-log) | `l` `lg` | Pretty log: current, branch, compare, search |
+| [`status`](#info-commands) | `st` | Repo status and changed files |
+| [`reflog`](#info-commands) | `rl` `rlg` | Pretty reflog |
+| [`last-commit`](#info-commands) | `lc` `lastc` | Show the last commit |
+| [`last-ref`](#info-commands) | `lr` `lastr` | Show the last reference |
+| [`prev`](#gitb-branch) | `-` | Switch to previous branch (`cd -`) |
+
+---
+
+### `gitb commit`
+
+> **Multi-word modes.** Modifiers can be written as separate words in any order — `gitb commit ai fast push`, `gitb c ai f p`, and `gitb c aifp` are all equivalent. Modifier words: `ai`/`llm`/`i`, `fast`/`f`, `push`/`pu`/`p`, `scope`/`s`, `msg`/`m`, `staged`, `fixup`/`fix`/`x`, `amend`/`am`/`a`, `split`/`sp`/`sl`, `ticket`/`jira`/`j`/`t`, `last`/`l`, `revert`/`rev`. The `ff`/`ffp` ultrafast modes remain compact-only.
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Select files, build conventional message |
+| `msg` | `m` | Multiline message in `$EDITOR` |
+| `ticket` | `t` `jira` `j` | Prepend tracker ticket to header |
+| `fast` | `f` | `git add .` + commit without scope |
+| `fasts` | `fs` | `git add .` + commit with scope |
+| `push` | `p` `pu` | Commit + push |
+| `fastp` | `fp` | Fast commit + push |
+| `fastsp` | `fsp` `fps` | Fast commit with scope + push |
+| `split` | `sp` `sl` | One commit per detected scope (heuristic, manual messages) |
+| `splitp` | `spp` `slp` | `split` + push |
+| `aisplit` | `isplit` `aispl` `ispl` | AI refines grouping and writes each message |
+| `aisplitp` | `isplitp` `aisplp` `islp` | `aisplit` + push |
+| `ff` | | Ultrafast: add all, AI-grouped split, AI messages, no prompts |
+| `ffp` | `ffpush` | `ff` + push |
+| `ai` | `llm` `i` | AI-generated commit message |
+| `aif` | `llmf` `if` | Fast AI commit, no confirmation |
+| `aip` | `llmp` `ip` | AI commit + push |
+| `aifp` | `llmfp` `ifp` | Fast AI commit + push |
+| `ais` | `llms` `is` | AI summary, manual type/scope |
+| `aim` | `llmm` `im` | AI multiline message |
+| `fixup` | `fix` `x` | Fixup commit (for autosquash) |
+| `fixupp` | `fixp` `xp` | Fixup commit + push |
+| `fastfix` | `fx` | Fast fixup (all files) |
+| `fastfixp` | `fxp` | Fast fixup + push |
+| `amend` | `am` `a` | Amend selected files into last commit |
+| `amendf` | `amf` `af` | Amend all files |
+| `last` | `l` | Edit last commit's message |
+| `revert` | `rev` | Revert a selected commit |
+
+### `gitb push`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Show commits, push with conflict handling |
+| `yes` | `y` | Push without confirmation |
+| `force` | `f` | Force push (use after rebase/amend) |
+| `list` | `log` `l` | List unpushed commits only |
+
+### `gitb pull`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Smart pull (strategy picker) |
+| `fetch` | `fe` | Fetch only |
+| `all` | `fa` | Fetch all branches |
+| `upd` | `u` | Update remote refs / prune |
+| `ffonly` | `ff` | Fast-forward only |
+| `merge` | `m` | Always create merge commit |
+| `rebase` | `r` | Rebase current onto remote |
+| `interactive` | `ri` `rs` | Interactive rebase + autosquash |
+
+### `gitb branch`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Pick a local branch to switch |
+| `list` | `l` | List local branches |
+| `remote` | `re` `r` | Fetch and switch to a remote branch |
+| `main` | `def` `m` | Quick-switch to default branch |
+| `tag` | `t` | Checkout to a specific tag |
+| `new` | `n` `c` | Create branch from current |
+| `newd` | `nd` `cd` | Switch to main, pull, branch off |
+| `delete` | `del` `d` | Delete branches (orphaned, merged, or selected) |
+| `prev` | `p` `-` | Switch to previous branch (`cd -`) |
+| `recent` | `rc` | Pick from recently checked-out branches |
+| `gone` | `g` | Delete locals whose remote tracking branch is gone |
+
+### `gitb tag`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Lightweight tag from `HEAD` |
+| `annotated` | `a` `an` | Annotated tag with message |
+| `commit` | `c` `co` `cm` | Tag from a selected commit |
+| `all` | `al` | Annotated tag from selected commit |
+| `push` | `p` `ps` `ph` | Push a tag |
+| `push-all` | `pa` | Push all tags |
+| `delete` | `del` `d` | Delete a local tag |
+| `delete-all` | `da` | Delete all local tags |
+| `list` | `log` `l` | List local tags |
+| `remote` | `fetch` `r` | Fetch and list remote tags |
+
+### `gitb merge`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Pick a branch to merge into current |
+| `main` | `master` `m` | Merge default branch into current |
+| `to-main` | `to-master` `tm` | Switch to main, merge current branch in |
+| `remote` | `r` | Fetch + select a remote branch to merge |
+
+### `gitb rebase`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Pick a base branch |
+| `main` | `master` `m` | Rebase current onto default |
+| `interactive` | `i` | Interactive rebase from picked commit |
+| `autosquash` | `a` `s` `ia` | Interactive rebase with `--autosquash` |
+| `fastautosquash` | `fast` `sf` `f` | Autosquash without interaction |
+| `pull` | `p` | Take commits from selected branch into current |
+
+### `gitb cherry`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Pick commits from a branch interactively |
+| `<commit-hash>` | | Shorthand for cherry-pick by hash |
+| `hash` | `hs` | Cherry-pick a specific hash |
+| `range` | `r` | Cherry-pick a range (`A..B`) |
+| `abort` | `a` | Abort current cherry-pick |
+| `continue` | `cont` `c` | Continue after resolving conflicts |
+
+### `gitb sync`
+
+Fetch the default branch and update your current branch. Useful mid-feature.
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Fetch main + rebase current onto it |
+| `push` | `p` | …then force-push |
+| `merge` | `m` | Use merge instead of rebase |
+| `mergep` | `mp` `pm` | Merge + push |
+
+### `gitb wip` / `unwip`
+
+Snapshot work-in-progress in one keystroke; restore it later.
+
+| Command | Mode | Description |
+|---------|------|-------------|
+| `gitb wip` | `<empty>` | Stage all, WIP commit, push |
+| `gitb wip` | `nopush` (`np` `n`) | Stage all + WIP commit, no push |
+| `gitb unwip` | | Undo the WIP commit, restore the changes to the working tree |
+
+### `gitb fixup`
+
+End-to-end fixup-and-autosquash so you don't have to chain `gitb c fix` + `gitb r a`.
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Select files, pick commit, fixup, autosquash |
+| `fast` | `f` | Add all, pick commit, fixup, autosquash |
+| `commit` | `c` | Create fixup commit only (= `gitb c x`) |
+| `push` | `p` | Fixup + autosquash + force-push |
+| `fastp` | `fp` `pf` | Fast variant + force-push |
+
+### `gitb undo`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` / `commit` | `c` | Undo last commit (`reset --soft HEAD~1`) — keeps changes staged |
+| `amend` | `a` | Restore pre-amend state via reflog |
+| `merge` | `m` | Abort or undo last merge |
+| `rebase` | `r` | Abort or undo last rebase (`ORIG_HEAD`) |
+| `stash` | `s` | Re-stash a popped/applied stash |
+
+### `gitb reset`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Reset last commit (mixed) |
+| `soft` | `s` | Soft reset last commit |
+| `undo` | `u` | Undo last reset |
+| `interactive` | `i` | Pick commit to reset to |
+| `ref` | `r` | Reset to a `HEAD` reference (reflog recovery) |
+
+### `gitb stash`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Interactive stash menu |
+| `select` | `sel` | Stash specific files |
+| `all` | | Stash everything including untracked |
+| `list` | `l` | List all stashes |
+| `pop` | `p` | Apply and remove |
+| `show` | `s` | Preview stash |
+| `apply` | `a` | Apply without removing |
+| `drop` | `d` | Delete stash |
+
+### `gitb hook`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Interactive action menu |
+| `list` | `l` | All hooks with status |
+| `create` | `new` `c` | New hook from templates |
+| `edit` | `e` | Edit existing hook |
+| `toggle` | `t` | Enable/disable hook |
+| `remove` | `rm` `r` | Delete hook(s) |
+| `test` | `run` `check` | Test hook execution |
+| `show` | `cat` `view` `s` | Display hook contents |
+
+### `gitb config`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Show current configuration |
+| `user` | `u` `name` `email` | Set name and email |
+| `default` | `def` `d` `b` `main` | Set default branch |
+| `separator` | `sep` `s` | Branch-name separator |
+| `editor` | `ed` `e` | Commit-message editor |
+| `ticket` | `ti` `t` `jira` | Ticket prefix for commits/branches |
+| `scopes` | `sc` `s` | Common scopes |
+| `ai` | `llm` `key` | AI API key |
+| `model` | | Default AI model |
+| `proxy` | `prx` `p` | HTTP proxy for AI calls |
+| `delete` | `unset` `del` | Remove global config |
+
+### `gitb log`
+
+| Mode | Aliases | Description |
+|------|---------|-------------|
+| `<empty>` | | Pretty log for current branch |
+| `branch` | `b` | Pick a branch to log |
+| `compare` | `comp` `c` | Compare two branches |
+| `search` | `s` | Search commits |
+
+**Search sub-modes:** `message`/`msg`/`m`, `author`/`a`, `file`/`f`, `content`/`pickaxe`/`p`, `date`/`d`, `hash`/`commit`/`h`.
+
+### Info commands
+
+| Command | Aliases | Description |
+|---------|---------|-------------|
+| `status` | `st` | Repo info and changed files |
+| `reflog` | `rl` `rlg` | Pretty reflog |
+| `last-commit` | `lc` `lastc` | Show the last commit |
+| `last-ref` | `lr` `lastr` | Show the last reference |
+
+---
+
+## Configuration
+
+`gitb cfg` (no args) prints the active configuration. Settings live in standard `git config`, so they're per-repo by default — use `--global` for everywhere.
+
+| Key | Set via | Purpose |
+|-----|---------|---------|
+| `user.name` / `user.email` | `gitb cfg user` | Your identity |
+| `gitbasher.branch` | `gitb cfg default` | Default branch (`main`, `master`, …) |
+| `gitbasher.sep` | `gitb cfg separator` | Branch-name separator (`/`, `-`, …) |
+| `gitbasher.editor` | `gitb cfg editor` | Editor for messages |
+| `gitbasher.ticket` | `gitb cfg ticket` | Ticket prefix (`PROJ-`) |
+| `gitbasher.scopes` | `gitb cfg scopes` | Suggested commit scopes |
+| `gitbasher.ai-api-key` | `gitb cfg ai` | AI provider API key (or `GITB_AI_API_KEY` env) |
+| `gitbasher.ai-model[-task]` | `gitb cfg model` | AI model overrides |
+| `gitbasher.proxy` | `gitb cfg proxy` | HTTP proxy for AI calls |
+
+**Aliases for shell users:**
 ```bash
-# Check bash version (needs 4.0+)
-bash --version
-
-# macOS: Install newer bash (and Homebrew if needed)
-# 1) Install Homebrew (if missing):
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-# 2) Install bash:
-brew install bash
-# 3) Optional: make it your default shell (restart Terminal after):
-sudo sh -c 'echo /opt/homebrew/bin/bash >> /etc/shells' && chsh -s /opt/homebrew/bin/bash
-
-# Ubuntu/Debian: upgrade bash
-sudo apt update && sudo apt install --only-upgrade bash
-```
-
-#### ❓ Git operations fail
-```bash
-# Check git version (needs 2.23+)
-git --version
-
-# Update git
-# macOS: brew install git
-# Ubuntu: sudo apt install git
-# Or download from: https://git-scm.com/downloads
-```
-
-### 🔧 System Requirements
-
-| **System** | **Bash** | **Git** | **Installation Method** |
-|------------|----------|---------|------------------------|
-| **Linux** | 4.0+ | 2.23+ | `apt install bash git` |
-| **macOS** | 4.0+ | 2.23+ | `brew install bash git` |
-| **Windows** | WSL | WSL | `wsl --install` then Linux steps |
-
-### 💡 Pro Tips
-
-#### 🎯 **Workflow Optimization**
-```bash
-# Set up aliases for even faster usage
-echo 'alias gc="gitb c"' >> ~/.bashrc
-echo 'alias gp="gitb p"' >> ~/.bashrc
+echo 'alias gc="gitb c"'   >> ~/.bashrc
+echo 'alias gp="gitb p"'   >> ~/.bashrc
 echo 'alias gpu="gitb pu"' >> ~/.bashrc
-echo 'alias gb="gitb b"' >> ~/.bashrc
+echo 'alias gb="gitb b"'   >> ~/.bashrc
 ```
 
-### 🆘 **Still Having Issues?**
+**zsh tip:** if zsh autocorrects `gitb` → `git`, add `alias gitb='nocorrect gitb'` to `~/.zshrc`.
 
-**Ask for help**: [Open an issue](https://github.com/maxbolgarin/gitbasher/issues) or contact [@maxbolgarin](https://t.me/maxbolgarin)
+---
 
-### 🗑️ **Uninstall**
+## Troubleshooting
+
+<details>
+<summary><b>Command not found: gitb</b></summary>
 
 ```bash
-# Remove gitbasher
-sudo rm /usr/local/bin/gitb
-# or
-rm ~/.local/bin/gitb
-
-# Remove configuration (optional)
-rm -rf ~/.gitbasher
+which gitb                    # check install location
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc   # if installed to ~/.local/bin
 ```
+Reinstall via npm (`npm install -g gitbasher`) or curl (see [install](#install-in-10-seconds)).
+</details>
 
+<details>
+<summary><b>Permission denied during install</b></summary>
 
-## Roadmap for v4
+Use `sudo`, or install to `~/.local/bin` and add it to `PATH`.
+</details>
 
-1. Add support of multi modes, e.g. `gitb c fastp` -> `gitb c fast push` to prevent from a lot of modes to support all combinations
-2. Add more interactive menus, because it is difficult to remember all commands and modes
-3. Add better error messages and settings for verbosity
-4. Add more AI APIs providers
-
-## Testing
-
-**gitbasher** includes a comprehensive test suite using [BATS (Bash Automated Testing System)](https://github.com/bats-core/bats-core) to ensure code quality and prevent regressions during refactoring.
-
-### Running Tests
+<details>
+<summary><b>AI features not working</b></summary>
 
 ```bash
-# Run all tests
-make test
-
-# Run a specific test file
-make test-file FILE=test_sanitization.bats
-
-# Or use the test runner directly
-cd tests
-./run_tests.sh
+gitb cfg              # check config
+gitb cfg ai           # set API key
+gitb cfg proxy        # in restricted regions
 ```
+</details>
 
-### Test Coverage
+<details>
+<summary><b>"Bad substitution" or bash errors</b></summary>
 
-- **115+ tests** across multiple test files
-- Input sanitization (security-critical)
-- Git operations (commit, push, pull, merge, rebase)
-- Branch management
-- Common utilities
+`bash --version` must be 4.0+.
 
-See [tests/README.md](tests/README.md) for detailed testing documentation.
+- macOS: `brew install bash` (and optionally make it default: `sudo sh -c 'echo /opt/homebrew/bin/bash >> /etc/shells' && chsh -s /opt/homebrew/bin/bash`)
+- Ubuntu/Debian: `sudo apt update && sudo apt install --only-upgrade bash`
+</details>
+
+<details>
+<summary><b>System requirements</b></summary>
+
+| OS | Bash | Git | Install |
+|----|------|-----|---------|
+| Linux | 4.0+ | 2.23+ | `apt install bash git` |
+| macOS | 4.0+ | 2.23+ | `brew install bash git` |
+| Windows | WSL | WSL | `wsl --install` then Linux steps |
+</details>
+
+<details>
+<summary><b>Uninstall</b></summary>
+
+```bash
+npm uninstall -g gitbasher           # if installed via npm
+sudo rm /usr/local/bin/gitb          # if installed via curl
+rm -rf ~/.gitbasher                  # remove config (optional)
+```
+</details>
+
+**Still stuck?** [Open an issue](https://github.com/maxbolgarin/gitbasher/issues) or ping [@maxbolgarin](https://t.me/maxbolgarin) on Telegram.
+
+---
 
 ## Contributing
 
-If you'd like to contribute to **gitbasher**, make a fork and submit a pull request. You also can open an issue or text me on Telegram: https://t.me/maxbolgarin
+PRs welcome. Workflow:
 
-### Development Workflow
+1. Fork and create a feature branch
+2. **Write tests first** (BATS, see [tests/README.md](tests/README.md))
+3. Implement
+4. `make test` — all tests must pass
+5. Open a PR
 
-1. Fork the repository
-2. Create a feature branch
-3. **Write tests first** for new functionality
-4. Implement your changes
-5. Run tests: `make test`
-6. Ensure all tests pass
-7. Submit a pull request
+```bash
+make build               # rebuild dist/gitb
+make test                # run all 115+ tests
+make test-file FILE=test_sanitization.bats
+```
 
-#### Maintainers
+**Maintainer:** [@maxbolgarin](https://github.com/maxbolgarin)
 
-* [maxbolgarin](https://github.com/maxbolgarin)
-
-#### License
-
-The source code license is MIT, as described in the [LICENSE](./LICENSE) file.
+**License:** MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

Rewrites `README.md` to be optimized for a top-repo first impression: punchy hero, install in 10 seconds, 60-second quick start, then a complete reference. Also closes documentation gaps where multiple shipped commands and modes were not listed.

## What changed

- **Hero + install up front** — npm one-liner shown first, standalone curl below; 10-line "what does it do" code block sets expectations immediately.
- **60-second quick start** — minimal command list a new user can copy-paste.
- **"All features at a glance"** — single grouped table giving the full surface area in one view (23 commands, 60+ aliases, 100+ modes).
- **Documents previously undocumented commands**: `cherry`, `sync`, `wip` / `unwip`, `fixup`, `undo`, `last-commit`, `last-ref`.
- **Adds missing modes** to existing command tables:
  - `branch`: `prev`, `recent`, `gone`, `tag`
  - `merge`: `remote`
  - `rebase`: `fastautosquash`, `pull`
  - `config`: `model`
- **AI section consolidated** — setup, commands, model overrides, and per-task config keys in one place.
- **Common workflows** expanded to include `sync`, `wip/unwip`, `undo`, branch hygiene (`recent`, `gone`, `prev`).
- **Troubleshooting** moved into collapsible `<details>` blocks so the long page stays scannable.
- **Configuration table** added so users can see every `gitbasher.*` git-config key in one place.

## Test plan

- [x] All command/alias rows verified against `scripts/gitb.sh` and each module's `case` statement
- [x] AI model defaults match `scripts/ai.sh`
- [x] No broken anchors in the table of contents
- [x] Install commands unchanged (still point to `releases/latest/download/gitb` and `npm install -g gitbasher`)

https://claude.ai/code/session_01XP5Bso2HQku2ufu69jZBbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01XP5Bso2HQku2ufu69jZBbk)_