### PR TITLE
feat(push): richer post-push and post-tag links

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -466,6 +466,161 @@ function get_repo_name {
 }
 
 
+### Detect remote host kind from a repo URL
+# $1: repo URL (optional, defaults to current repo)
+# Return: "github", "gitlab", "bitbucket" or empty string
+function get_repo_host {
+    local repo=${1:-$(get_repo)}
+    if [[ "$repo" == *"github"* ]]; then
+        echo "github"
+    elif [[ "$repo" == *"gitlab"* ]]; then
+        echo "gitlab"
+    elif [[ "$repo" == *"bitbucket"* ]]; then
+        echo "bitbucket"
+    else
+        echo ""
+    fi
+}
+
+
+### URL to a branch in the remote repo
+# $1: branch name, $2: repo URL (optional)
+function get_branch_url {
+    local branch=$1
+    local repo=${2:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)    echo "${repo}/tree/${branch}";;
+        gitlab)    echo "${repo}/-/tree/${branch}";;
+        bitbucket) echo "${repo}/branch/${branch}";;
+    esac
+}
+
+
+### URL to a commit in the remote repo
+# $1: commit hash, $2: repo URL (optional)
+function get_commit_url {
+    local hash=$1
+    local repo=${2:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)    echo "${repo}/commit/${hash}";;
+        gitlab)    echo "${repo}/-/commit/${hash}";;
+        bitbucket) echo "${repo}/commits/${hash}";;
+    esac
+}
+
+
+### URL to open a new pull/merge request from a branch
+# $1: base branch, $2: source branch, $3: repo URL (optional)
+function get_new_pr_url {
+    local base=$1
+    local branch=$2
+    local repo=${3:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)    echo "${repo}/compare/${base}...${branch}?expand=1";;
+        gitlab)    echo "${repo}/-/merge_requests/new?merge_request%5Bsource_branch%5D=${branch}&merge_request%5Btarget_branch%5D=${base}";;
+        bitbucket) echo "${repo}/pull-requests/new?source=${branch}&dest=${base}";;
+    esac
+}
+
+
+### URL to the list of pull/merge requests
+# $1: repo URL (optional)
+function get_prs_url {
+    local repo=${1:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)    echo "${repo}/pulls";;
+        gitlab)    echo "${repo}/-/merge_requests";;
+        bitbucket) echo "${repo}/pull-requests";;
+    esac
+}
+
+
+### URL to CI runs filtered by branch (or all runs when branch is empty)
+# $1: branch name (optional), $2: repo URL (optional)
+function get_ci_url {
+    local branch=$1
+    local repo=${2:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)
+            if [ -n "$branch" ]; then
+                echo "${repo}/actions?query=branch%3A${branch}"
+            else
+                echo "${repo}/actions"
+            fi;;
+        gitlab)
+            if [ -n "$branch" ]; then
+                echo "${repo}/-/pipelines?ref=${branch}"
+            else
+                echo "${repo}/-/pipelines"
+            fi;;
+        bitbucket)
+            echo "${repo}/pipelines";;
+    esac
+}
+
+
+### Human-friendly label for the CI system
+# $1: repo URL (optional)
+function get_ci_label {
+    case "$(get_repo_host "${1:-$(get_repo)}")" in
+        github)    echo "Actions";;
+        gitlab)    echo "Pipeline";;
+        bitbucket) echo "Pipelines";;
+        *)         echo "CI";;
+    esac
+}
+
+
+### URL to a tag page in the remote repo
+# $1: tag name, $2: repo URL (optional)
+function get_tag_url {
+    local tag=$1
+    local repo=${2:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)    echo "${repo}/releases/tag/${tag}";;
+        gitlab)    echo "${repo}/-/tags/${tag}";;
+        bitbucket) echo "${repo}/src/${tag}";;
+    esac
+}
+
+
+### URL to create a new release for a tag
+# $1: tag name, $2: repo URL (optional)
+function get_new_release_url {
+    local tag=$1
+    local repo=${2:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)    echo "${repo}/releases/new?tag=${tag}";;
+        gitlab)    echo "${repo}/-/releases/new?tag_name=${tag}";;
+    esac
+}
+
+
+### URL to all releases / downloads
+# $1: repo URL (optional)
+function get_releases_url {
+    local repo=${1:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)    echo "${repo}/releases";;
+        gitlab)    echo "${repo}/-/releases";;
+        bitbucket) echo "${repo}/downloads/?tab=tags";;
+    esac
+}
+
+
+### URL to CI runs triggered by a tag
+# $1: tag name, $2: repo URL (optional)
+function get_tag_ci_url {
+    local tag=$1
+    local repo=${2:-$(get_repo)}
+    case "$(get_repo_host "$repo")" in
+        github)    echo "${repo}/actions?query=ref%3Arefs%2Ftags%2F${tag}";;
+        gitlab)    echo "${repo}/-/pipelines?ref=${tag}";;
+        bitbucket) echo "${repo}/pipelines";;
+    esac
+}
+
+
 ### Function prints current config
 function print_configuration {
     echo -e "${YELLOW}Current configuration:${ENDCOLOR}"

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -20,32 +20,68 @@ function push {
     push_output=$(git push $1 ${origin_name} ${current_branch} 2>&1)
     push_code=$?
 
-    if [ $push_code -eq 0 ] ; then 
+    if [ $push_code -eq 0 ] ; then
         echo -e "${GREEN}Successful push!${ENDCOLOR}"
 
         repo=$(get_repo)
+        host=$(get_repo_host "$repo")
+        head_hash=$(git rev-parse HEAD 2>/dev/null)
+
         echo -e "${YELLOW}Repo:${ENDCOLOR}\t${repo}"
+
+        # Direct link to the just-pushed commit
+        if [ -n "$head_hash" ]; then
+            commit_url=$(get_commit_url "$head_hash" "$repo")
+            if [ -n "$commit_url" ]; then
+                echo -e "${YELLOW}Commit:${ENDCOLOR}\t${commit_url}"
+            fi
+        fi
+
         if [[ ${current_branch} != ${main_branch} ]]; then
-            link=$(echo "$push_output" | grep "https://" | sed 's|^remote:[[:space:]]*||')
-            if [[ $repo == *"github"* ]]; then
-                if [ "$link" != "" ]; then
+            branch_url=$(get_branch_url "${current_branch}" "$repo")
+            if [ -n "$branch_url" ]; then
+                echo -e "${YELLOW}Branch:${ENDCOLOR}\t${branch_url}"
+            fi
+
+            # Some hosts include a PR/MR link in the push output (first push, etc.)
+            link=$(echo "$push_output" | grep -Eo "https?://[^[:space:]]+" | head -n 1 | sed 's|^remote:[[:space:]]*||')
+
+            if [ "$host" = "github" ]; then
+                if [ -n "$link" ]; then
                     echo -e "${YELLOW}New PR:${ENDCOLOR}\t${link}"
                 else
-                    echo -e "${YELLOW}PRs:${ENDCOLOR}\t${repo}/pulls"
+                    new_pr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
+                    echo -e "${YELLOW}New PR:${ENDCOLOR}\t${new_pr_url}"
                 fi
-            elif [[ $repo == *"gitlab"* ]]; then
-                is_new=$(echo "$push_output" | grep "create a merge request")
-                if [ "$is_new" != "" ]; then
-                    echo -e "${YELLOW}New MR:${ENDCOLOR}\t${link}"
-                else
-                    if [ "$link" != "" ]; then
-                        echo -e "${YELLOW}MR:${ENDCOLOR}\t${link}"
+            elif [ "$host" = "gitlab" ]; then
+                if [ -n "$link" ]; then
+                    is_new=$(echo "$push_output" | grep -i "create a merge request")
+                    if [ -n "$is_new" ]; then
+                        echo -e "${YELLOW}New MR:${ENDCOLOR}\t${link}"
                     else
-                        echo -e "${YELLOW}MRs:${ENDCOLOR}\t${repo}/merge_requests"
+                        echo -e "${YELLOW}MR:${ENDCOLOR}\t${link}"
                     fi
+                else
+                    new_mr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
+                    echo -e "${YELLOW}New MR:${ENDCOLOR}\t${new_mr_url}"
+                fi
+            elif [ "$host" = "bitbucket" ]; then
+                if [ -n "$link" ]; then
+                    echo -e "${YELLOW}New PR:${ENDCOLOR}\t${link}"
+                else
+                    new_pr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
+                    echo -e "${YELLOW}New PR:${ENDCOLOR}\t${new_pr_url}"
                 fi
             fi
         fi
+
+        # Link to CI runs for this branch
+        ci_url=$(get_ci_url "${current_branch}" "$repo")
+        if [ -n "$ci_url" ]; then
+            ci_label=$(get_ci_label "$repo")
+            echo -e "${YELLOW}${ci_label}:${ENDCOLOR}\t${ci_url}"
+        fi
+
         exit
     fi
 

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -33,6 +33,7 @@ function push_tag {
     fi
     
     repo=$(get_repo)
+    host=$(get_repo_host "$repo")
 
     # Print `push-all` result
     if [ -n "$all" ]; then
@@ -43,10 +44,16 @@ function push_tag {
         number_of_tags=${#lines_with_success[@]}
         if [ "$number_of_tags" != 0 ]; then
             echo -e "${GREEN}Pushed successfully!${ENDCOLOR}"
-            
+
             for index in "${!lines_with_success[@]}"
             do
-                echo -e "\t$(sed -e 's#.*\-> \(\)#\1#' <<< "${lines_with_success[index]}" )"
+                pushed_tag=$(sed -e 's#.*\-> \(\)#\1#' <<< "${lines_with_success[index]}" )
+                pushed_tag_url=$(get_tag_url "$pushed_tag" "$repo")
+                if [ -n "$pushed_tag_url" ]; then
+                    echo -e "\t${pushed_tag}\t${pushed_tag_url}"
+                else
+                    echo -e "\t${pushed_tag}"
+                fi
             done
             echo
         fi
@@ -67,7 +74,7 @@ function push_tag {
             echo -e "${YELLOW}Repo:${ENDCOLOR} ${repo}"
             exit
         fi
-        
+
         echo -e "${RED}Cannot push! Error message:${ENDCOLOR}"
         echo "$push_output"
         exit $push_code
@@ -84,11 +91,26 @@ function push_tag {
 
     echo -e "${YELLOW}Repo:${ENDCOLOR}\t${repo}"
 
-    if [ -z "$all" ]; then
-        if [[ $repo == *"github"* ]]; then
-            echo -e "${YELLOW}Tag:${ENDCOLOR}\t${repo}/releases/tag/$1"
-        elif [[ $repo == *"gitlab"* ]]; then
-            echo -e "${YELLOW}Tag:${ENDCOLOR}\t${repo}/-/tags/$1"
+    if [ -z "$all" ] && [ -n "$1" ]; then
+        tag_url=$(get_tag_url "$1" "$repo")
+        if [ -n "$tag_url" ]; then
+            echo -e "${YELLOW}Tag:${ENDCOLOR}\t${tag_url}"
+        fi
+
+        release_url=$(get_new_release_url "$1" "$repo")
+        if [ -n "$release_url" ]; then
+            echo -e "${YELLOW}Release:${ENDCOLOR}\t${release_url}"
+        fi
+
+        ci_url=$(get_tag_ci_url "$1" "$repo")
+        if [ -n "$ci_url" ]; then
+            ci_label=$(get_ci_label "$repo")
+            echo -e "${YELLOW}${ci_label}:${ENDCOLOR}\t${ci_url}"
+        fi
+    elif [ -n "$all" ]; then
+        releases_url=$(get_releases_url "$repo")
+        if [ -n "$releases_url" ]; then
+            echo -e "${YELLOW}Releases:${ENDCOLOR}\t${releases_url}"
         fi
     fi
 }

--- a/tests/test_common_utils.bats
+++ b/tests/test_common_utils.bats
@@ -52,6 +52,135 @@ teardown() {
     [ -z "$repo_name" ]
 }
 
+# ===== get_repo_host tests =====
+
+@test "get_repo_host: detects github" {
+    [ "$(get_repo_host "https://github.com/user/repo")" = "github" ]
+}
+
+@test "get_repo_host: detects gitlab" {
+    [ "$(get_repo_host "https://gitlab.com/user/repo")" = "gitlab" ]
+}
+
+@test "get_repo_host: detects bitbucket" {
+    [ "$(get_repo_host "https://bitbucket.org/user/repo")" = "bitbucket" ]
+}
+
+@test "get_repo_host: returns empty for unknown host" {
+    [ -z "$(get_repo_host "https://example.com/user/repo")" ]
+}
+
+# ===== URL builder tests =====
+
+@test "get_branch_url: github" {
+    [ "$(get_branch_url "feat" "https://github.com/u/r")" = "https://github.com/u/r/tree/feat" ]
+}
+
+@test "get_branch_url: gitlab" {
+    [ "$(get_branch_url "feat" "https://gitlab.com/u/r")" = "https://gitlab.com/u/r/-/tree/feat" ]
+}
+
+@test "get_branch_url: bitbucket" {
+    [ "$(get_branch_url "feat" "https://bitbucket.org/u/r")" = "https://bitbucket.org/u/r/branch/feat" ]
+}
+
+@test "get_commit_url: github" {
+    [ "$(get_commit_url "abc123" "https://github.com/u/r")" = "https://github.com/u/r/commit/abc123" ]
+}
+
+@test "get_commit_url: gitlab" {
+    [ "$(get_commit_url "abc123" "https://gitlab.com/u/r")" = "https://gitlab.com/u/r/-/commit/abc123" ]
+}
+
+@test "get_commit_url: bitbucket" {
+    [ "$(get_commit_url "abc123" "https://bitbucket.org/u/r")" = "https://bitbucket.org/u/r/commits/abc123" ]
+}
+
+@test "get_new_pr_url: github builds compare URL" {
+    result=$(get_new_pr_url "main" "feat" "https://github.com/u/r")
+    [ "$result" = "https://github.com/u/r/compare/main...feat?expand=1" ]
+}
+
+@test "get_new_pr_url: gitlab builds new MR URL with source and target" {
+    result=$(get_new_pr_url "main" "feat" "https://gitlab.com/u/r")
+    [[ "$result" =~ "merge_requests/new" ]]
+    [[ "$result" =~ "source_branch%5D=feat" ]]
+    [[ "$result" =~ "target_branch%5D=main" ]]
+}
+
+@test "get_new_pr_url: bitbucket" {
+    result=$(get_new_pr_url "main" "feat" "https://bitbucket.org/u/r")
+    [ "$result" = "https://bitbucket.org/u/r/pull-requests/new?source=feat&dest=main" ]
+}
+
+@test "get_ci_url: github with branch" {
+    [ "$(get_ci_url "feat" "https://github.com/u/r")" = "https://github.com/u/r/actions?query=branch%3Afeat" ]
+}
+
+@test "get_ci_url: github without branch" {
+    [ "$(get_ci_url "" "https://github.com/u/r")" = "https://github.com/u/r/actions" ]
+}
+
+@test "get_ci_url: gitlab with branch" {
+    [ "$(get_ci_url "feat" "https://gitlab.com/u/r")" = "https://gitlab.com/u/r/-/pipelines?ref=feat" ]
+}
+
+@test "get_ci_url: bitbucket" {
+    [ "$(get_ci_url "feat" "https://bitbucket.org/u/r")" = "https://bitbucket.org/u/r/pipelines" ]
+}
+
+@test "get_ci_label: github" {
+    [ "$(get_ci_label "https://github.com/u/r")" = "Actions" ]
+}
+
+@test "get_ci_label: gitlab" {
+    [ "$(get_ci_label "https://gitlab.com/u/r")" = "Pipeline" ]
+}
+
+@test "get_ci_label: bitbucket" {
+    [ "$(get_ci_label "https://bitbucket.org/u/r")" = "Pipelines" ]
+}
+
+@test "get_ci_label: unknown host falls back to CI" {
+    [ "$(get_ci_label "https://example.com/u/r")" = "CI" ]
+}
+
+@test "get_tag_url: github" {
+    [ "$(get_tag_url "v1.0.0" "https://github.com/u/r")" = "https://github.com/u/r/releases/tag/v1.0.0" ]
+}
+
+@test "get_tag_url: gitlab" {
+    [ "$(get_tag_url "v1.0.0" "https://gitlab.com/u/r")" = "https://gitlab.com/u/r/-/tags/v1.0.0" ]
+}
+
+@test "get_tag_url: bitbucket" {
+    [ "$(get_tag_url "v1.0.0" "https://bitbucket.org/u/r")" = "https://bitbucket.org/u/r/src/v1.0.0" ]
+}
+
+@test "get_new_release_url: github" {
+    [ "$(get_new_release_url "v1.0.0" "https://github.com/u/r")" = "https://github.com/u/r/releases/new?tag=v1.0.0" ]
+}
+
+@test "get_new_release_url: gitlab" {
+    [ "$(get_new_release_url "v1.0.0" "https://gitlab.com/u/r")" = "https://gitlab.com/u/r/-/releases/new?tag_name=v1.0.0" ]
+}
+
+@test "get_releases_url: github" {
+    [ "$(get_releases_url "https://github.com/u/r")" = "https://github.com/u/r/releases" ]
+}
+
+@test "get_releases_url: gitlab" {
+    [ "$(get_releases_url "https://gitlab.com/u/r")" = "https://gitlab.com/u/r/-/releases" ]
+}
+
+@test "get_tag_ci_url: github" {
+    [ "$(get_tag_ci_url "v1.0.0" "https://github.com/u/r")" = "https://github.com/u/r/actions?query=ref%3Arefs%2Ftags%2Fv1.0.0" ]
+}
+
+@test "get_tag_ci_url: gitlab" {
+    [ "$(get_tag_ci_url "v1.0.0" "https://gitlab.com/u/r")" = "https://gitlab.com/u/r/-/pipelines?ref=v1.0.0" ]
+}
+
 # ===== git_status tests =====
 
 @test "git_status: shows modified files" {


### PR DESCRIPTION
## Summary

After `gitb push`/`gitb tag`, gitbasher now prints concrete links to the pushed commit, branch, PR/MR review, CI runs, and tag/release pages — instead of only generic "PRs" / "MRs" indexes. Bitbucket joins GitHub and GitLab as a recognized host.

### Why
Today the post-push output sends users to `…/pulls` or `…/merge_requests` rather than a specific review or pipeline run. This change points them at the exact thing they likely want next: review the diff, check CI, draft a release.

### What changed

**`scripts/common.sh`** — new helpers (host-aware, GitHub/GitLab/Bitbucket):
- `get_repo_host` — detect host kind from URL
- `get_branch_url`, `get_commit_url`
- `get_new_pr_url`, `get_prs_url`
- `get_ci_url`, `get_ci_label`
- `get_tag_url`, `get_new_release_url`, `get_releases_url`, `get_tag_ci_url`

**`scripts/push.sh`** — after a successful push, print:
- `Repo:`
- `Commit:` direct link to `HEAD`
- `Branch:` tree view (when not on `main`)
- `New PR:` / `New MR:` — uses the link returned by the remote when available, otherwise builds a `compare/<main>...<branch>?expand=1` (GitHub), `merge_requests/new?…` (GitLab) or `pull-requests/new?…` (Bitbucket) URL
- `Actions:` / `Pipeline:` — CI runs filtered by branch

**`scripts/tag.sh`** — after `gitb tag push`/`push-all`:
- single tag: `Repo:`, `Tag:`, `Release:` (new-release form), `Actions:`/`Pipeline:` for `refs/tags/<tag>`
- push-all: per-tag URLs in the success list, plus `Releases:` index

### Tests
30 new bats cases in `tests/test_common_utils.bats` covering each URL builder for GitHub, GitLab, and Bitbucket.

## Test plan
- [ ] `make test` passes (only pre-existing env-related failures remain)
- [ ] `gitb push` on a branch ahead of `main` shows `Commit:`, `Branch:`, `New PR:`, and `Actions:`/`Pipeline:` links
- [ ] `gitb tag push v1.0.0` shows `Tag:`, `Release:`, and CI links
- [ ] `gitb tag push-all` lists each pushed tag with its URL
- [ ] Verify on a GitLab and Bitbucket repo (host detection)

https://claude.ai/code/session_01CmWBwvPfEnxiRnVKqMsRXM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmWBwvPfEnxiRnVKqMsRXM)_