### PR TITLE
fix: keyboard, URL, push-list bugs and 165 new tests

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -320,39 +320,39 @@ function normalize_key {
         return
     fi
 
-    # Convert to lowercase first
+    # Convert ASCII uppercase to lowercase (tr only handles ASCII)
     normalized_key=$(echo "$key" | tr '[:upper:]' '[:lower:]')
 
-    # Map Russian layout to Latin (same physical key positions)
+    # Map Russian layout (both lowercase and uppercase) to Latin (same physical key positions)
     case "$normalized_key" in
-        "й") normalized_key="q" ;;
-        "ц") normalized_key="w" ;;
-        "у") normalized_key="e" ;;
-        "к") normalized_key="r" ;;
-        "е") normalized_key="t" ;;
-        "н") normalized_key="y" ;;
-        "г") normalized_key="u" ;;
-        "ш") normalized_key="i" ;;
-        "щ") normalized_key="o" ;;
-        "з") normalized_key="p" ;;
-        "х") normalized_key="[" ;;
-        "ъ") normalized_key="]" ;;
-        "ф") normalized_key="a" ;;
-        "ы") normalized_key="s" ;;
-        "в") normalized_key="d" ;;
-        "а") normalized_key="f" ;;
-        "п") normalized_key="g" ;;
-        "р") normalized_key="h" ;;
-        "о") normalized_key="j" ;;
-        "л") normalized_key="k" ;;
-        "д") normalized_key="l" ;;
-        "я") normalized_key="z" ;;
-        "ч") normalized_key="x" ;;
-        "с") normalized_key="c" ;;
-        "м") normalized_key="v" ;;
-        "и") normalized_key="b" ;;
-        "т") normalized_key="n" ;;
-        "ь") normalized_key="m" ;;
+        "й"|"Й") normalized_key="q" ;;
+        "ц"|"Ц") normalized_key="w" ;;
+        "у"|"У") normalized_key="e" ;;
+        "к"|"К") normalized_key="r" ;;
+        "е"|"Е") normalized_key="t" ;;
+        "н"|"Н") normalized_key="y" ;;
+        "г"|"Г") normalized_key="u" ;;
+        "ш"|"Ш") normalized_key="i" ;;
+        "щ"|"Щ") normalized_key="o" ;;
+        "з"|"З") normalized_key="p" ;;
+        "х"|"Х") normalized_key="[" ;;
+        "ъ"|"Ъ") normalized_key="]" ;;
+        "ф"|"Ф") normalized_key="a" ;;
+        "ы"|"Ы") normalized_key="s" ;;
+        "в"|"В") normalized_key="d" ;;
+        "а"|"А") normalized_key="f" ;;
+        "п"|"П") normalized_key="g" ;;
+        "р"|"Р") normalized_key="h" ;;
+        "о"|"О") normalized_key="j" ;;
+        "л"|"Л") normalized_key="k" ;;
+        "д"|"Д") normalized_key="l" ;;
+        "я"|"Я") normalized_key="z" ;;
+        "ч"|"Ч") normalized_key="x" ;;
+        "с"|"С") normalized_key="c" ;;
+        "м"|"М") normalized_key="v" ;;
+        "и"|"И") normalized_key="b" ;;
+        "т"|"Т") normalized_key="n" ;;
+        "ь"|"Ь") normalized_key="m" ;;
     esac
 }
 
@@ -446,15 +446,25 @@ function wrong_mode {
 # Return: url to repo
 function get_repo {
     local remote_name=${origin_name:-origin}
+    local repo
     repo=$(git config --get "remote.${remote_name}.url")
-    repo="${repo/"com:"/"com/"}"
-    repo="${repo/"io:"/"io/"}"
-    repo="${repo/"org:"/"org/"}"
-    repo="${repo/"net:"/"net/"}"
-    repo="${repo/"dev:"/"dev/"}"
-    repo="${repo/"ru:"/"ru/"}"
-    repo="${repo/"git@"/"https://"}"
-    repo="${repo/".git"/""}" 
+    if [ -z "$repo" ]; then
+        echo ""
+        return
+    fi
+
+    # Convert SSH-style URLs (git@host:user/repo) into https URLs by replacing
+    # the first ':' after the host with '/'. This is more robust than
+    # whitelisting specific TLDs and supports any host (github.com, gitlab.com,
+    # self-hosted servers with .ai/.uk/.de/etc).
+    if [[ "$repo" =~ ^git@([^:]+):(.*)$ ]]; then
+        repo="https://${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    elif [[ "$repo" =~ ^ssh://git@([^/]+)/(.*)$ ]]; then
+        repo="https://${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    fi
+
+    # Strip .git suffix if present
+    repo="${repo%.git}"
     echo "$repo"
 }
 
@@ -644,14 +654,20 @@ function git_status {
 ### Function prints staged files with color-coded status
 # Added: green, Modified: yellow, Deleted: red
 function print_staged_files {
+    local staged_diff
+    staged_diff=$(git diff --name-status --cached)
+    if [ -z "$staged_diff" ]; then
+        return
+    fi
     while IFS=$'\t' read -r status file _; do
+        [ -z "$file" ] && continue
         case "${status:0:1}" in
             A) echo -e "\t${GREEN}${file}${ENDCOLOR}" ;;
             M) echo -e "\t${YELLOW}${file}${ENDCOLOR}" ;;
             D) echo -e "\t${RED}${file}${ENDCOLOR}" ;;
             *) echo -e "\t${file}${ENDCOLOR}" ;;
         esac
-    done <<< "$(git diff --name-status --cached)"
+    done <<< "$staged_diff"
 }
 
 
@@ -792,7 +808,7 @@ function get_push_list {
         return
     fi
     
-    push_list_check=$(git --no-pager log $origin/$1..HEAD 2>&1)
+    push_list_check=$(git --no-pager log $origin/$1..HEAD 2>&1 || true)
     if [[ $push_list_check != *"unknown revision or path not in the working tree"* ]] && [[ $push_list_check != *"fatal:"* ]]; then
         push_list=$(commit_list 999 "tab" $origin/$1..HEAD)
         history_from="$origin/$1"
@@ -808,7 +824,7 @@ function get_push_list {
         fi
     fi
     
-    base_commit=$(diff -u <(git rev-list --first-parent $1) <(git rev-list --first-parent $2) | sed -ne 's/^ //p' | head -1)
+    base_commit=$(diff -u <(git rev-list --first-parent $1 2>/dev/null) <(git rev-list --first-parent $2 2>/dev/null) | sed -ne 's/^ //p' | head -1 || true)
     if [ -n "$base_commit" ]; then
         push_list=$(commit_list 999 "tab" $base_commit..HEAD)
         history_from="${base_commit::7}"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -88,10 +88,10 @@ function validate_git_url {
     # git@github.com:user/repo.git
     # ssh://git@server.com/repo.git
     # /path/to/repo.git (local)
-    if [[ "$cleaned" =~ ^https?://[a-zA-Z0-9.-]+/[a-zA-Z0-9._/-]+(.git)?$ ]] || \
-       [[ "$cleaned" =~ ^git@[a-zA-Z0-9.-]+:[a-zA-Z0-9._/-]+(.git)?$ ]] || \
-       [[ "$cleaned" =~ ^ssh://[a-zA-Z0-9@.-]+/[a-zA-Z0-9._/-]+(.git)?$ ]] || \
-       [[ "$cleaned" =~ ^[a-zA-Z0-9._/-]+(.git)?$ ]]; then
+    if [[ "$cleaned" =~ ^https?://[a-zA-Z0-9.-]+/[a-zA-Z0-9._/-]+(\.git)?$ ]] || \
+       [[ "$cleaned" =~ ^git@[a-zA-Z0-9.-]+:[a-zA-Z0-9._/-]+(\.git)?$ ]] || \
+       [[ "$cleaned" =~ ^ssh://[a-zA-Z0-9@.-]+/[a-zA-Z0-9._/-]+(\.git)?$ ]] || \
+       [[ "$cleaned" =~ ^[a-zA-Z0-9._/-]+(\.git)?$ ]]; then
         
         # Length check
         if [ ${#cleaned} -le 500 ]; then

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,28 +15,54 @@ The test suite provides:
 
 ### Current Test Files
 
-1. **test_sanitization.bats** (173 tests)
+1. **test_sanitization.bats**
    - Input sanitization for git names, file paths, commit messages
    - Email validation
    - Numeric input validation
    - Command sanitization
    - **Critical for security** - prevents command injection attacks
 
-2. **test_common_utils.bats**
+2. **test_additional_sanitization.bats**
+   - Edge cases for sanitize_text_input, validate_scope_list
+   - Boundary-length tests for git names, file paths, commit messages
+   - Additional validate_email and validate_numeric_input cases
+
+3. **test_common_utils.bats**
    - Repository URL handling
    - Git status formatting
    - Commit listing
    - Branch listing and filtering
    - Common utility functions
 
-3. **test_branch_operations.bats**
+4. **test_repository_helpers.bats**
+   - Extended get_repo URL transformation cases (TLDs, subgroups, ssh://)
+   - ref_list, get_push_list edge cases
+   - print_staged_files, switch error paths
+   - get_config_value / set_config_value
+
+5. **test_keyboard_input.bats**
+   - normalize_key (ASCII + Cyrillic, lower + upper case)
+   - is_yes / is_no
+   - sanitize_choice_input
+
+6. **test_url_validation.bats**
+   - validate_git_url (https, ssh, git@, edge cases)
+   - validate_proxy_url
+   - mask_api_key
+
+7. **test_ai_config.bats**
+   - AI API key, model, proxy getters/setters
+   - Per-task model resolution
+   - Diff and history limit defaults
+
+8. **test_branch_operations.bats**
    - Branch creation and deletion
    - Branch switching
    - Remote branch operations
    - Branch naming validation
    - Merge preparation
 
-4. **test_git_operations.bats**
+9. **test_git_operations.bats**
    - Commit operations
    - Push/pull operations
    - Merge and rebase

--- a/tests/test_additional_sanitization.bats
+++ b/tests/test_additional_sanitization.bats
@@ -1,0 +1,326 @@
+#!/usr/bin/env bats
+
+# Tests for sanitization functions not covered by test_sanitization.bats:
+# sanitize_text_input, validate_scope_list, additional sanitize_git_name and
+# sanitize_file_path edge cases.
+
+load setup_suite
+
+setup() {
+    source_gitbasher
+}
+
+# ===== sanitize_text_input tests =====
+
+@test "sanitize_text_input: accepts plain text" {
+    sanitize_text_input "Hello world"
+    [ $? -eq 0 ]
+    [ "$sanitized_text" = "Hello world" ]
+}
+
+@test "sanitize_text_input: trims surrounding whitespace" {
+    sanitize_text_input "  spaced  "
+    [ $? -eq 0 ]
+    [ "$sanitized_text" = "spaced" ]
+}
+
+@test "sanitize_text_input: rejects empty input" {
+    ! sanitize_text_input ""
+}
+
+@test "sanitize_text_input: rejects whitespace-only input" {
+    ! sanitize_text_input "   "
+}
+
+@test "sanitize_text_input: enforces default 500 char limit" {
+    local long
+    long=$(printf 'a%.0s' {1..501})
+    ! sanitize_text_input "$long"
+}
+
+@test "sanitize_text_input: respects custom max length" {
+    sanitize_text_input "abcdef" 10
+    [ $? -eq 0 ]
+    ! sanitize_text_input "abcdefghijklmn" 10
+}
+
+@test "sanitize_text_input: accepts text exactly at max length" {
+    sanitize_text_input "abcde" 5
+    [ $? -eq 0 ]
+    [ "$sanitized_text" = "abcde" ]
+}
+
+@test "sanitize_text_input: strips control characters" {
+    sanitize_text_input "$(printf 'foo\001bar')"
+    [ $? -eq 0 ]
+    [[ "$sanitized_text" != *$'\001'* ]]
+}
+
+@test "sanitize_text_input: preserves UTF-8 content" {
+    sanitize_text_input "Привет мир"
+    [ $? -eq 0 ]
+    [ "$sanitized_text" = "Привет мир" ]
+}
+
+# ===== validate_scope_list tests =====
+
+@test "validate_scope_list: accepts single scope" {
+    validate_scope_list "feat"
+    [ $? -eq 0 ]
+    [ "$validated_scopes" = "feat" ]
+}
+
+@test "validate_scope_list: accepts multiple scopes" {
+    validate_scope_list "feat fix docs"
+    [ $? -eq 0 ]
+    [ "$validated_scopes" = "feat fix docs" ]
+}
+
+@test "validate_scope_list: accepts up to nine scopes" {
+    validate_scope_list "a b c d e f g h i"
+    [ $? -eq 0 ]
+}
+
+@test "validate_scope_list: rejects more than nine scopes" {
+    ! validate_scope_list "a b c d e f g h i j"
+}
+
+@test "validate_scope_list: rejects empty input" {
+    ! validate_scope_list ""
+}
+
+@test "validate_scope_list: rejects scope with digits" {
+    ! validate_scope_list "feat1 fix"
+}
+
+@test "validate_scope_list: rejects scope with special chars" {
+    ! validate_scope_list "feat-fix"
+    ! validate_scope_list "feat,fix"
+    ! validate_scope_list "feat;fix"
+}
+
+@test "validate_scope_list: rejects double-spaced scopes" {
+    ! validate_scope_list "feat  fix"
+}
+
+# ===== Additional sanitize_git_name tests =====
+
+@test "sanitize_git_name: accepts single character name" {
+    sanitize_git_name "a"
+    [ $? -eq 0 ]
+    [ "$sanitized_git_name" = "a" ]
+}
+
+@test "sanitize_git_name: accepts long valid name (255 chars)" {
+    local name
+    name=$(printf 'a%.0s' {1..255})
+    sanitize_git_name "$name"
+    [ $? -eq 0 ]
+}
+
+@test "sanitize_git_name: rejects name longer than 255 chars" {
+    local name
+    name=$(printf 'a%.0s' {1..256})
+    ! sanitize_git_name "$name"
+}
+
+@test "sanitize_git_name: strips leading @ symbol" {
+    sanitize_git_name "@feature"
+    [ $? -eq 0 ]
+    [ "$sanitized_git_name" = "feature" ]
+}
+
+@test "sanitize_git_name: removes parentheses from injection attempts" {
+    sanitize_git_name 'feat$(rm)'
+    [ $? -eq 0 ]
+    [[ "$sanitized_git_name" != *'$'* ]]
+    [[ "$sanitized_git_name" != *'('* ]]
+    [[ "$sanitized_git_name" != *')'* ]]
+}
+
+@test "sanitize_git_name: removes backticks" {
+    sanitize_git_name 'feat`whoami`'
+    [ $? -eq 0 ]
+    [[ "$sanitized_git_name" != *'`'* ]]
+}
+
+@test "sanitize_git_name: removes pipes and redirects" {
+    sanitize_git_name "feat|cat"
+    [ $? -eq 0 ]
+    [[ "$sanitized_git_name" != *'|'* ]]
+    sanitize_git_name "feat>file"
+    [ $? -eq 0 ]
+    [[ "$sanitized_git_name" != *'>'* ]]
+}
+
+@test "sanitize_git_name: rejects name with only forbidden chars" {
+    ! sanitize_git_name '$()`'
+    ! sanitize_git_name ';;;'
+}
+
+# ===== Additional sanitize_file_path tests =====
+
+@test "sanitize_file_path: accepts nested directory paths" {
+    sanitize_file_path "src/lib/utils/helper.sh"
+    [ $? -eq 0 ]
+    [ "$sanitized_file_path" = "src/lib/utils/helper.sh" ]
+}
+
+@test "sanitize_file_path: accepts paths with brackets" {
+    sanitize_file_path "src/[abc].txt"
+    [ $? -eq 0 ]
+}
+
+@test "sanitize_file_path: accepts dotfiles" {
+    sanitize_file_path ".gitignore"
+    [ $? -eq 0 ]
+}
+
+@test "sanitize_file_path: removes leading rm command" {
+    sanitize_file_path "rm important.txt"
+    [ $? -eq 0 ]
+    [[ "$sanitized_file_path" != "rm important.txt" ]]
+}
+
+@test "sanitize_file_path: removes trailing rm" {
+    sanitize_file_path "important.txt rm"
+    [ $? -eq 0 ]
+    [[ "$sanitized_file_path" != *" rm" ]]
+}
+
+@test "sanitize_file_path: removes rm after &&" {
+    sanitize_file_path "file && rm trash"
+    [ $? -eq 0 ]
+    [[ "$sanitized_file_path" != *"rm trash"* ]]
+}
+
+@test "sanitize_file_path: removes rm after pipe" {
+    sanitize_file_path "file | rm trash"
+    [ $? -eq 0 ]
+    [[ "$sanitized_file_path" != *"rm trash"* ]]
+}
+
+@test "sanitize_file_path: accepts path at exactly 1000 chars" {
+    local path
+    path=$(printf 'a%.0s' {1..1000})
+    sanitize_file_path "$path"
+    [ $? -eq 0 ]
+}
+
+# ===== Additional sanitize_commit_message tests =====
+
+@test "sanitize_commit_message: accepts message at exactly 2000 chars" {
+    local msg
+    msg=$(printf 'a%.0s' {1..2000})
+    sanitize_commit_message "$msg"
+    [ $? -eq 0 ]
+}
+
+@test "sanitize_commit_message: preserves tabs" {
+    sanitize_commit_message "$(printf 'feat:\tadd feature')"
+    [ $? -eq 0 ]
+    [[ "$sanitized_commit_message" == *$'\t'* ]]
+}
+
+@test "sanitize_commit_message: rejects whitespace-only message" {
+    ! sanitize_commit_message "   "
+    ! sanitize_commit_message "$(printf '\t\t\t')"
+}
+
+@test "sanitize_commit_message: handles emojis" {
+    sanitize_commit_message "feat: ✨ add sparkles"
+    [ $? -eq 0 ]
+    [ "$sanitized_commit_message" = "feat: ✨ add sparkles" ]
+}
+
+# ===== Additional sanitize_command tests =====
+
+@test "sanitize_command: accepts editor name" {
+    sanitize_command "nano"
+    [ $? -eq 0 ]
+    [ "$sanitized_command" = "nano" ]
+}
+
+@test "sanitize_command: accepts code-with-dash" {
+    sanitize_command "code-insiders"
+    [ $? -eq 0 ]
+    [ "$sanitized_command" = "code-insiders" ]
+}
+
+@test "sanitize_command: rejects command starting with dash" {
+    ! sanitize_command "-flag"
+}
+
+@test "sanitize_command: rejects path traversal in command" {
+    ! sanitize_command "../bin/evil"
+}
+
+@test "sanitize_command: rejects backticks" {
+    ! sanitize_command 'vim`whoami`'
+}
+
+@test "sanitize_command: rejects too long command" {
+    local cmd
+    cmd=$(printf 'a%.0s' {1..101})
+    ! sanitize_command "$cmd"
+}
+
+# ===== Additional validate_email tests =====
+
+@test "validate_email: rejects email longer than 254 chars" {
+    local local_part
+    local_part=$(printf 'a%.0s' {1..250})
+    local email="${local_part}@x.com"  # 257 chars
+    ! validate_email "$email"
+}
+
+@test "validate_email: accepts email at boundary (254 chars)" {
+    local local_part
+    local_part=$(printf 'a%.0s' {1..247})
+    local email="${local_part}@x.com"  # 254 chars
+    validate_email "$email"
+    [ $? -eq 0 ]
+}
+
+@test "validate_email: rejects email with multiple @" {
+    ! validate_email "a@b@c.com"
+}
+
+@test "validate_email: rejects email with spaces" {
+    ! validate_email "user name@example.com"
+}
+
+@test "validate_email: accepts email with single-letter TLD rejection" {
+    ! validate_email "user@example.c"
+}
+
+@test "validate_email: rejects email with disallowed local-part chars" {
+    ! validate_email "us!er@example.com"
+    ! validate_email "us(er@example.com"
+}
+
+# ===== Additional validate_numeric_input tests =====
+
+@test "validate_numeric_input: accepts large valid number" {
+    validate_numeric_input "999999"
+    [ $? -eq 0 ]
+    [ "$validated_number" = "999999" ]
+}
+
+@test "validate_numeric_input: rejects empty input" {
+    ! validate_numeric_input ""
+}
+
+@test "validate_numeric_input: rejects number with leading whitespace" {
+    ! validate_numeric_input " 5"
+}
+
+@test "validate_numeric_input: rejects scientific notation" {
+    ! validate_numeric_input "1e5"
+}
+
+@test "validate_numeric_input: accepts boundary values" {
+    validate_numeric_input "10" "10" "10"
+    [ $? -eq 0 ]
+    [ "$validated_number" = "10" ]
+}

--- a/tests/test_ai_config.bats
+++ b/tests/test_ai_config.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+
+# Tests for AI config getters/setters and helpers in ai.sh.
+# These verify config persistence and default-value handling without
+# making any real API calls.
+
+load setup_suite
+
+setup() {
+    setup_test_repo
+    source_gitbasher
+    source "${GITBASHER_ROOT}/scripts/ai.sh"
+    cd "$TEST_REPO"
+    # Clear any inherited env that would leak into get_ai_api_key
+    unset GITB_AI_API_KEY
+}
+
+teardown() {
+    cleanup_test_repo
+}
+
+# ===== get_ai_api_key / set_ai_api_key =====
+
+@test "get_ai_api_key: returns empty when not set" {
+    val=$(get_ai_api_key)
+    [ -z "$val" ]
+}
+
+@test "get_ai_api_key: prefers env var over git config" {
+    set_ai_api_key "config-key" >/dev/null
+    GITB_AI_API_KEY="env-key"
+    val=$(GITB_AI_API_KEY="env-key" get_ai_api_key)
+    [ "$val" = "env-key" ]
+}
+
+@test "get_ai_api_key: reads from git config when env not set" {
+    set_ai_api_key "stored-key" >/dev/null
+    val=$(get_ai_api_key)
+    [ "$val" = "stored-key" ]
+}
+
+@test "set_ai_api_key: persists to git config" {
+    set_ai_api_key "my-test-key" >/dev/null
+    val=$(git config --local --get gitbasher.ai-api-key)
+    [ "$val" = "my-test-key" ]
+}
+
+# ===== get_ai_model / set_ai_model =====
+
+@test "get_ai_model: returns empty when not set" {
+    val=$(get_ai_model)
+    [ -z "$val" ]
+}
+
+@test "set_ai_model: persists override" {
+    set_ai_model "openai/gpt-4o" >/dev/null
+    val=$(get_ai_model)
+    [ "$val" = "openai/gpt-4o" ]
+}
+
+# ===== get_ai_model_for =====
+
+@test "get_ai_model_for: returns simple default when nothing set" {
+    val=$(get_ai_model_for "simple")
+    [ -n "$val" ]
+}
+
+@test "get_ai_model_for: returns full default when nothing set" {
+    val=$(get_ai_model_for "full")
+    [ -n "$val" ]
+}
+
+@test "get_ai_model_for: returns grouping default when nothing set" {
+    val=$(get_ai_model_for "grouping")
+    [ -n "$val" ]
+}
+
+@test "get_ai_model_for: per-task override beats global" {
+    set_ai_model "global-model" >/dev/null
+    set_ai_model_for "simple" "task-model" >/dev/null
+    val=$(get_ai_model_for "simple")
+    [ "$val" = "task-model" ]
+}
+
+@test "get_ai_model_for: global override applies when no per-task override" {
+    set_ai_model "global-model" >/dev/null
+    val=$(get_ai_model_for "subject")
+    [ "$val" = "global-model" ]
+}
+
+@test "get_ai_model_for: unknown task falls back to simple default" {
+    val=$(get_ai_model_for "unknown")
+    simple_val=$(get_ai_model_for "simple")
+    [ "$val" = "$simple_val" ]
+}
+
+# ===== get_ai_proxy / set_ai_proxy =====
+
+@test "get_ai_proxy: returns empty by default" {
+    val=$(get_ai_proxy)
+    [ -z "$val" ]
+}
+
+@test "set_ai_proxy: persists value" {
+    set_ai_proxy "http://proxy.example.com:8080" >/dev/null
+    val=$(get_ai_proxy)
+    [ "$val" = "http://proxy.example.com:8080" ]
+}
+
+# ===== Diff limits =====
+
+@test "get_ai_diff_limit: returns default of 300" {
+    val=$(get_ai_diff_limit)
+    [ "$val" = "300" ]
+}
+
+@test "set_ai_diff_limit: persists custom value" {
+    set_ai_diff_limit "500" >/dev/null
+    val=$(get_ai_diff_limit)
+    [ "$val" = "500" ]
+}
+
+@test "get_ai_diff_max_chars: returns default of 20000" {
+    val=$(get_ai_diff_max_chars)
+    [ "$val" = "20000" ]
+}
+
+@test "set_ai_diff_max_chars: persists custom value" {
+    set_ai_diff_max_chars "30000" >/dev/null
+    val=$(get_ai_diff_max_chars)
+    [ "$val" = "30000" ]
+}
+
+@test "get_ai_commit_history_limit: returns default of 10" {
+    val=$(get_ai_commit_history_limit)
+    [ "$val" = "10" ]
+}
+
+@test "set_ai_commit_history_limit: persists custom value" {
+    set_ai_commit_history_limit "20" >/dev/null
+    val=$(get_ai_commit_history_limit)
+    [ "$val" = "20" ]
+}

--- a/tests/test_git_operations.bats
+++ b/tests/test_git_operations.bats
@@ -105,6 +105,7 @@ teardown() {
     cd "$TEMP_CLONE"
     git config user.name "Test User"
     git config user.email "test@example.com"
+    git config commit.gpgsign false
     make_test_commit "remote.txt" "Remote commit"
     git push origin main
 

--- a/tests/test_keyboard_input.bats
+++ b/tests/test_keyboard_input.bats
@@ -1,0 +1,202 @@
+#!/usr/bin/env bats
+
+# Tests for keyboard input helpers in common.sh:
+# normalize_key, is_yes, is_no, sanitize_choice_input
+# These handle case-insensitive input and alternative keyboard layouts (Russian).
+
+load setup_suite
+
+setup() {
+    source_gitbasher
+}
+
+# ===== normalize_key tests =====
+
+@test "normalize_key: passes through lowercase ASCII" {
+    normalize_key "y"
+    [ "$normalized_key" = "y" ]
+    normalize_key "n"
+    [ "$normalized_key" = "n" ]
+    normalize_key "q"
+    [ "$normalized_key" = "q" ]
+}
+
+@test "normalize_key: lowercases ASCII uppercase" {
+    normalize_key "Y"
+    [ "$normalized_key" = "y" ]
+    normalize_key "N"
+    [ "$normalized_key" = "n" ]
+    normalize_key "Q"
+    [ "$normalized_key" = "q" ]
+}
+
+@test "normalize_key: empty input returns empty" {
+    normalize_key ""
+    [ -z "$normalized_key" ]
+}
+
+@test "normalize_key: digits pass through" {
+    normalize_key "0"
+    [ "$normalized_key" = "0" ]
+    normalize_key "9"
+    [ "$normalized_key" = "9" ]
+}
+
+@test "normalize_key: maps Russian lowercase to Latin" {
+    normalize_key "й"
+    [ "$normalized_key" = "q" ]
+    normalize_key "н"
+    [ "$normalized_key" = "y" ]
+    normalize_key "т"
+    [ "$normalized_key" = "n" ]
+    normalize_key "ф"
+    [ "$normalized_key" = "a" ]
+}
+
+@test "normalize_key: maps Russian uppercase to Latin" {
+    normalize_key "Й"
+    [ "$normalized_key" = "q" ]
+    normalize_key "Н"
+    [ "$normalized_key" = "y" ]
+    normalize_key "Т"
+    [ "$normalized_key" = "n" ]
+    normalize_key "Ф"
+    [ "$normalized_key" = "a" ]
+}
+
+@test "normalize_key: maps all Russian alphabet keys" {
+    # Spot-check a representative subset of mappings (lowercase)
+    declare -A expected=(
+        [ц]=w [у]=e [к]=r [е]=t [г]=u [ш]=i [щ]=o [з]=p
+        [ы]=s [в]=d [а]=f [п]=g [р]=h [о]=j [л]=k [д]=l
+        [я]=z [ч]=x [с]=c [м]=v [и]=b [ь]=m
+    )
+    for ru in "${!expected[@]}"; do
+        normalize_key "$ru"
+        [ "$normalized_key" = "${expected[$ru]}" ] || \
+            { echo "Failed: '$ru' -> '$normalized_key', expected '${expected[$ru]}'"; return 1; }
+    done
+}
+
+@test "normalize_key: special chars pass through" {
+    normalize_key "="
+    [ "$normalized_key" = "=" ]
+    normalize_key "/"
+    [ "$normalized_key" = "/" ]
+}
+
+# ===== is_yes tests =====
+
+@test "is_yes: accepts lowercase y" {
+    is_yes "y"
+}
+
+@test "is_yes: accepts uppercase Y" {
+    is_yes "Y"
+}
+
+@test "is_yes: accepts empty (Enter key)" {
+    is_yes ""
+}
+
+@test "is_yes: accepts Russian н (Y position lowercase)" {
+    is_yes "н"
+}
+
+@test "is_yes: accepts Russian Н (Y position uppercase)" {
+    is_yes "Н"
+}
+
+@test "is_yes: rejects n" {
+    ! is_yes "n"
+}
+
+@test "is_yes: rejects arbitrary letter" {
+    ! is_yes "x"
+    ! is_yes "a"
+}
+
+@test "is_yes: rejects digit" {
+    ! is_yes "1"
+}
+
+# ===== is_no tests =====
+
+@test "is_no: accepts lowercase n" {
+    is_no "n"
+}
+
+@test "is_no: accepts uppercase N" {
+    is_no "N"
+}
+
+@test "is_no: accepts Russian т (N position lowercase)" {
+    is_no "т"
+}
+
+@test "is_no: accepts Russian Т (N position uppercase)" {
+    is_no "Т"
+}
+
+@test "is_no: rejects empty input" {
+    ! is_no ""
+}
+
+@test "is_no: rejects y" {
+    ! is_no "y"
+}
+
+@test "is_no: rejects arbitrary letter" {
+    ! is_no "x"
+}
+
+# ===== sanitize_choice_input tests =====
+
+@test "sanitize_choice_input: accepts y" {
+    sanitize_choice_input "y"
+    [ "$sanitized_choice" = "y" ]
+}
+
+@test "sanitize_choice_input: accepts Y (lowercased)" {
+    sanitize_choice_input "Y"
+    [ "$sanitized_choice" = "y" ]
+}
+
+@test "sanitize_choice_input: accepts n" {
+    sanitize_choice_input "n"
+    [ "$sanitized_choice" = "n" ]
+}
+
+@test "sanitize_choice_input: accepts digit" {
+    sanitize_choice_input "5"
+    [ "$sanitized_choice" = "5" ]
+}
+
+@test "sanitize_choice_input: accepts =" {
+    sanitize_choice_input "="
+    [ "$sanitized_choice" = "=" ]
+}
+
+@test "sanitize_choice_input: accepts Russian н as y" {
+    sanitize_choice_input "н"
+    [ "$sanitized_choice" = "y" ]
+}
+
+@test "sanitize_choice_input: rejects empty" {
+    ! sanitize_choice_input ""
+}
+
+@test "sanitize_choice_input: rejects multi-character ASCII" {
+    ! sanitize_choice_input "yes"
+}
+
+@test "sanitize_choice_input: rejects punctuation by default" {
+    ! sanitize_choice_input ";"
+    ! sanitize_choice_input "&"
+}
+
+@test "sanitize_choice_input: respects custom pattern" {
+    sanitize_choice_input "a" "^[abc]$"
+    [ "$sanitized_choice" = "a" ]
+    ! sanitize_choice_input "z" "^[abc]$"
+}

--- a/tests/test_repository_helpers.bats
+++ b/tests/test_repository_helpers.bats
@@ -1,0 +1,232 @@
+#!/usr/bin/env bats
+
+# Tests for repository helper functions in common.sh:
+# get_repo (extended cases), ref_list, get_push_list edge cases,
+# print_staged_files, switch error paths.
+
+load setup_suite
+
+setup() {
+    setup_test_repo
+    source_gitbasher
+    cd "$TEST_REPO"
+    current_branch="main"
+    main_branch="main"
+    origin_name="origin"
+}
+
+teardown() {
+    cleanup_test_repo
+    cleanup_remote_repo
+}
+
+# ===== get_repo: extended URL transformation tests =====
+
+@test "get_repo: transforms self-hosted .ai TLD" {
+    git remote add origin git@code.example.ai:user/repo.git
+    repo=$(get_repo)
+    [ "$repo" = "https://code.example.ai/user/repo" ]
+}
+
+@test "get_repo: transforms .uk TLD" {
+    git remote add origin git@server.example.uk:user/repo.git
+    repo=$(get_repo)
+    [ "$repo" = "https://server.example.uk/user/repo" ]
+}
+
+@test "get_repo: transforms .de TLD" {
+    git remote add origin git@server.example.de:user/repo.git
+    repo=$(get_repo)
+    [ "$repo" = "https://server.example.de/user/repo" ]
+}
+
+@test "get_repo: transforms ssh:// URL" {
+    git remote add origin ssh://git@code.example.com/user/repo.git
+    repo=$(get_repo)
+    [ "$repo" = "https://code.example.com/user/repo" ]
+}
+
+@test "get_repo: leaves https URLs unchanged (minus .git)" {
+    git remote add origin https://github.com/user/repo.git
+    repo=$(get_repo)
+    [ "$repo" = "https://github.com/user/repo" ]
+}
+
+@test "get_repo: handles URL without .git suffix" {
+    git remote add origin git@github.com:user/repo
+    repo=$(get_repo)
+    [ "$repo" = "https://github.com/user/repo" ]
+}
+
+@test "get_repo: handles nested groups (gitlab subgroups)" {
+    git remote add origin git@gitlab.com:group/sub/repo.git
+    repo=$(get_repo)
+    [ "$repo" = "https://gitlab.com/group/sub/repo" ]
+}
+
+@test "get_repo_name: works for all URL types" {
+    git remote add origin git@gitlab.com:group/sub/myrepo.git
+    name=$(get_repo_name)
+    [ "$name" = "myrepo" ]
+}
+
+# ===== ref_list tests =====
+
+@test "ref_list: populates refs_info and refs_hash" {
+    make_test_commit "file1.txt" "First"
+    make_test_commit "file2.txt" "Second"
+
+    ref_list 5
+    [ "${#refs_hash[@]}" -gt 0 ]
+    [ "${#refs_info[@]}" -gt 0 ]
+}
+
+@test "ref_list: respects limit parameter" {
+    for i in 1 2 3 4 5; do
+        make_test_commit "file$i.txt" "Commit $i"
+    done
+
+    ref_list 3
+    [ "${#refs_hash[@]}" -le 3 ]
+}
+
+# ===== get_push_list: edge cases =====
+
+@test "get_push_list: returns empty when no remote configured" {
+    get_push_list "main" "main" ""
+    [ -z "$push_list" ]
+    [ -z "$history_from" ]
+}
+
+@test "get_push_list: empty origin (whitespace-only)" {
+    get_push_list "main" "main" "   "
+    [ -z "$push_list" ]
+}
+
+@test "get_push_list: handles repo with new branch not on remote" {
+    setup_remote_repo
+
+    create_test_branch "feature/new"
+    make_test_commit "feature.txt" "Feature commit"
+
+    get_push_list "feature/new" "main" "origin"
+    [ -n "$push_list" ]
+}
+
+@test "get_push_list: shows multiple unpushed commits" {
+    setup_remote_repo
+
+    make_test_commit "f1.txt" "Commit 1"
+    make_test_commit "f2.txt" "Commit 2"
+    make_test_commit "f3.txt" "Commit 3"
+
+    get_push_list "main" "main" "origin"
+    count=$(echo -e "$push_list" | wc -l | tr -d ' ')
+    [ "$count" -eq 3 ]
+}
+
+# ===== print_staged_files tests =====
+
+@test "print_staged_files: shows added files in green" {
+    create_test_file "newfile.txt"
+    git add newfile.txt
+    output=$(print_staged_files)
+    [[ "$output" =~ "newfile.txt" ]]
+}
+
+@test "print_staged_files: shows nothing for empty index" {
+    output=$(print_staged_files)
+    # No staged files = no real content (just maybe whitespace)
+    [ -z "$(echo "$output" | tr -d '[:space:]')" ]
+}
+
+@test "print_staged_files: distinguishes modified files" {
+    echo "modified" > README.md
+    git add README.md
+    output=$(print_staged_files)
+    [[ "$output" =~ "README.md" ]]
+}
+
+@test "print_staged_files: distinguishes deleted files" {
+    git rm README.md >/dev/null
+    output=$(print_staged_files)
+    [[ "$output" =~ "README.md" ]]
+}
+
+# ===== switch tests =====
+
+@test "switch: switches to existing branch" {
+    create_test_branch "feature"
+    git checkout main
+
+    current_branch="main"
+    run switch "feature" "noinfo"
+    [ "$status" -eq 0 ]
+    [ "$(git branch --show-current)" = "feature" ]
+}
+
+@test "switch: same-branch detection" {
+    current_branch="main"
+    run switch "main" "noinfo"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Already" ]]
+}
+
+@test "switch: shows error for non-existent branch" {
+    current_branch="main"
+    run switch "nonexistent-branch" "noinfo"
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "Cannot switch" ]] || [[ "$output" =~ "did not match" ]]
+}
+
+# ===== get_config_value / set_config_value tests =====
+
+@test "get_config_value: returns default when not set" {
+    val=$(get_config_value "nonexistent.key" "fallback")
+    [ "$val" = "fallback" ]
+}
+
+@test "get_config_value: returns local value when set" {
+    git config --local "test.local" "localvalue"
+    val=$(get_config_value "test.local" "fallback")
+    [ "$val" = "localvalue" ]
+}
+
+@test "set_config_value: writes to local config by default" {
+    set_config_value "test.foo" "bar" >/dev/null
+    val=$(git config --local --get "test.foo")
+    [ "$val" = "bar" ]
+}
+
+@test "set_config_value: returns the value" {
+    val=$(set_config_value "test.return" "expected")
+    [ "$val" = "expected" ]
+}
+
+# ===== escape edge cases =====
+
+@test "escape: handles backslash" {
+    result=$(escape 'a\b' 'b')
+    [[ "$result" == *"\\b"* ]]
+}
+
+@test "escape: leaves string unchanged when sub absent" {
+    result=$(escape "hello world" "z")
+    [ "$result" = "hello world" ]
+}
+
+# ===== git_status detailed =====
+
+@test "git_status: detects modified+staged combo" {
+    create_test_file "newfile.txt" "v1"
+    git add newfile.txt
+    echo "v2" > newfile.txt
+    output=$(git_status)
+    [[ "$output" =~ "newfile.txt" ]]
+}
+
+@test "git_status: handles untracked files" {
+    create_test_file "untracked.txt"
+    output=$(git_status)
+    [[ "$output" =~ "untracked.txt" ]]
+}

--- a/tests/test_url_validation.bats
+++ b/tests/test_url_validation.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+
+# Tests for URL validation and AI helper functions:
+# validate_git_url (init.sh), validate_proxy_url (ai.sh), mask_api_key (ai.sh)
+
+load setup_suite
+
+setup() {
+    setup_test_repo
+    source_gitbasher
+    # Source ai.sh for mask_api_key and validate_proxy_url
+    source "${GITBASHER_ROOT}/scripts/ai.sh"
+    cd "$TEST_REPO"
+}
+
+teardown() {
+    cleanup_test_repo
+}
+
+# ===== validate_git_url tests =====
+
+@test "validate_git_url: accepts https URL with .git suffix" {
+    validate_git_url "https://github.com/user/repo.git"
+    [ $? -eq 0 ]
+    [ "$validated_url" = "https://github.com/user/repo.git" ]
+}
+
+@test "validate_git_url: accepts https URL without .git suffix" {
+    validate_git_url "https://github.com/user/repo"
+    [ $? -eq 0 ]
+    [ "$validated_url" = "https://github.com/user/repo" ]
+}
+
+@test "validate_git_url: accepts http URL" {
+    validate_git_url "http://internal.local/repo.git"
+    [ $? -eq 0 ]
+}
+
+@test "validate_git_url: accepts SSH URL with git@" {
+    validate_git_url "git@github.com:user/repo.git"
+    [ $? -eq 0 ]
+    [ "$validated_url" = "git@github.com:user/repo.git" ]
+}
+
+@test "validate_git_url: accepts ssh:// URL" {
+    validate_git_url "ssh://git@server.com/repo.git"
+    [ $? -eq 0 ]
+}
+
+@test "validate_git_url: accepts gitlab URL" {
+    validate_git_url "git@gitlab.com:group/subgroup/repo.git"
+    [ $? -eq 0 ]
+}
+
+@test "validate_git_url: accepts self-hosted server" {
+    validate_git_url "git@code.example.io:user/repo.git"
+    [ $? -eq 0 ]
+}
+
+@test "validate_git_url: rejects empty input" {
+    ! validate_git_url ""
+}
+
+@test "validate_git_url: rejects ftp URL" {
+    ! validate_git_url "ftp://example.com/repo.git"
+}
+
+@test "validate_git_url: rejects file URL with spaces" {
+    ! validate_git_url "https://github.com/user repo.git"
+}
+
+@test "validate_git_url: rejects URL with shell metacharacters" {
+    ! validate_git_url "https://github.com/user/repo.git;rm -rf /"
+    ! validate_git_url 'https://github.com/user/repo.git`whoami`'
+    ! validate_git_url 'https://github.com/user/repo.git$(id)'
+}
+
+@test "validate_git_url: rejects URL longer than 500 chars" {
+    local long
+    long="https://example.com/$(printf 'a%.0s' {1..500}).git"
+    ! validate_git_url "$long"
+}
+
+@test "validate_git_url: removes control characters" {
+    validate_git_url "$(printf 'https://example.com/repo\001.git')"
+    [ $? -eq 0 ]
+    [[ "$validated_url" != *$'\001'* ]]
+}
+
+# ===== validate_proxy_url tests =====
+
+@test "validate_proxy_url: accepts http proxy" {
+    validate_proxy_url "http://proxy.example.com:8080"
+    [ $? -eq 0 ]
+    [ "$validated_proxy_url" = "http://proxy.example.com:8080" ]
+}
+
+@test "validate_proxy_url: accepts https proxy" {
+    validate_proxy_url "https://proxy.example.com:8443"
+    [ $? -eq 0 ]
+}
+
+@test "validate_proxy_url: accepts socks5 proxy" {
+    validate_proxy_url "socks5://proxy.example.com:1080"
+    [ $? -eq 0 ]
+}
+
+@test "validate_proxy_url: accepts proxy with auth" {
+    validate_proxy_url "http://user:pass@proxy.example.com:8080"
+    [ $? -eq 0 ]
+}
+
+@test "validate_proxy_url: accepts host:port shorthand" {
+    validate_proxy_url "proxy.example.com:8080"
+    [ $? -eq 0 ]
+    [ "$validated_proxy_url" = "proxy.example.com:8080" ]
+}
+
+@test "validate_proxy_url: rejects empty input" {
+    ! validate_proxy_url ""
+}
+
+@test "validate_proxy_url: rejects URL without port" {
+    ! validate_proxy_url "http://proxy.example.com"
+}
+
+@test "validate_proxy_url: rejects unsupported scheme" {
+    ! validate_proxy_url "ftp://proxy.example.com:21"
+}
+
+@test "validate_proxy_url: rejects shell metacharacter sequences that break format" {
+    ! validate_proxy_url "http://proxy.example.com:8080; rm -rf /"
+    ! validate_proxy_url "http://proxy.example.com:8080 && id"
+}
+
+@test "validate_proxy_url: strips backticks before validation" {
+    # Sanitization removes backticks; result must not leak shell metacharacters
+    validate_proxy_url 'http://`whoami`@proxy.com:8080' || true
+    [[ "$validated_proxy_url" != *'`'* ]]
+}
+
+# ===== mask_api_key tests =====
+
+@test "mask_api_key: masks long key keeping last 4 chars" {
+    result=$(mask_api_key "sk-abcdefghij1234")
+    [ "$result" = "********1234" ]
+}
+
+@test "mask_api_key: returns empty for empty input" {
+    result=$(mask_api_key "")
+    [ -z "$result" ]
+}
+
+@test "mask_api_key: returns short keys unchanged (4 or fewer chars)" {
+    result=$(mask_api_key "1234")
+    [ "$result" = "1234" ]
+    result=$(mask_api_key "abc")
+    [ "$result" = "abc" ]
+}
+
+@test "mask_api_key: masks 5-character key (boundary)" {
+    result=$(mask_api_key "abcde")
+    [ "$result" = "********bcde" ]
+}
+
+@test "mask_api_key: never reveals key prefix" {
+    local key="sk-or-v1-abcdefghijklmnop"
+    result=$(mask_api_key "$key")
+    [[ "$result" != *"sk-or-v1"* ]]
+    [[ "$result" == *"mnop" ]]
+}


### PR DESCRIPTION
## Summary

Fixes a handful of latent bugs in the shell helpers and roughly **doubles the test suite** (113 → 277 tests).

### Bug fixes
- **`normalize_key`** (`scripts/common.sh`): `tr '[:upper:]' '[:lower:]'` only handles ASCII, so pressing CapsLock with a Russian layout (Й, Н, Ц, …) wasn't recognized. Mapped both lower and upper Cyrillic forms to the same Latin keys. Affects `is_yes` / `is_no` / `sanitize_choice_input`.
- **`get_repo`** (`scripts/common.sh`): SSH→HTTPS conversion was a hard-coded list of TLDs (`com`, `io`, `org`, `net`, `dev`, `ru`), so self-hosted servers on `.ai`, `.uk`, `.de`, etc. weren't transformed correctly. Replaced with a regex match on `git@host:path` / `ssh://git@host/path` that works for any host.
- **`get_push_list`** (`scripts/common.sh`): Now tolerates command-substitution failures so the documented "no remote" / "branch missing on origin" branches actually run when callers (like the test harness) have `inherit_errexit` set.
- **`print_staged_files`** (`scripts/common.sh`): Short-circuits when the index is empty instead of emitting a stray tab line.
- **`validate_git_url`** (`scripts/init.sh`): Escaped the `.` in `(\.git)?` for regex correctness.
- **`tests/test_git_operations.bats`**: The "pull from remote" test cloned the bare repo into a temp dir and inherited the global `commit.gpgsign=true` config, which broke the test in environments with signing configured. Now disables signing in the clone.

### New test files (~165 tests)
- `test_keyboard_input.bats` – `normalize_key`, `is_yes`, `is_no`, `sanitize_choice_input`
- `test_url_validation.bats` – `validate_git_url`, `validate_proxy_url`, `mask_api_key`
- `test_ai_config.bats` – AI key/model/proxy/limits getters & setters, per-task model resolution
- `test_additional_sanitization.bats` – `sanitize_text_input`, `validate_scope_list`, boundary-length cases
- `test_repository_helpers.bats` – extended `get_repo` cases, `ref_list`, `get_push_list` edges, `print_staged_files`, `switch`, `get_config_value` / `set_config_value`

All 277 tests pass via `make test`.

## Test plan
- [x] `make test` – 277 passing, 0 failing
- [x] `bash -n scripts/*.sh` – syntax clean
- [x] `shellcheck -S error scripts/*.sh` – clean
- [x] Manual `get_repo` checks for `.ai`, `.uk`, subgroups, ssh:// formats
- [x] Manual `normalize_key` checks for uppercase Cyrillic input

https://claude.ai/code/session_011efmqDpKqk99n7WqXckEZd

---
_Generated by [Claude Code](https://claude.ai/code/session_011efmqDpKqk99n7WqXckEZd)_