### PR TITLE
feat(install): add install.sh one-liner installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,26 @@ gitb undo              # roll back your last commit / amend / merge / rebase / s
 
 ## Install in 10 seconds
 
-**npm (easiest):**
+**One-liner (no Node required):**
+```bash
+curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/main/install.sh | bash
+```
+
+The installer auto-detects your OS, picks `/usr/local/bin` (with `sudo` if needed) or falls back to `~/.local/bin`, downloads the latest release, and prints a PATH hint if required. Override with env vars:
+
+```bash
+GITB_DIR=~/.local/bin   curl ... | bash    # custom location, no sudo
+GITB_VERSION=v3.10.2    curl ... | bash    # pin a release
+GITB_NO_SUDO=1          curl ... | bash    # never use sudo
+```
+
+**npm:**
 ```bash
 npm install -g gitbasher
 ```
 
-**Standalone binary (no Node required):**
-```bash
-GITB_PATH=/usr/local/bin/gitb && \
-sudo mkdir -p $(dirname $GITB_PATH) && \
-curl -fSL https://github.com/maxbolgarin/gitbasher/releases/latest/download/gitb | sudo tee $GITB_PATH > /dev/null && \
-sudo chmod +x $GITB_PATH
-```
-
 > Windows users: run inside [WSL](https://learn.microsoft.com/en-us/windows/wsl/setup/environment).
-> No `sudo`? Install to `~/.local/bin` and add it to `PATH`.
+> Prefer to inspect first? `curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/main/install.sh -o install.sh && less install.sh && bash install.sh`
 
 **Requirements:** `bash` 4.0+, `git` 2.23+ (macOS: `brew install bash git`).
 
@@ -593,7 +598,8 @@ gitb cfg proxy        # in restricted regions
 
 ```bash
 npm uninstall -g gitbasher           # if installed via npm
-sudo rm /usr/local/bin/gitb          # if installed via curl
+sudo rm /usr/local/bin/gitb          # if installed system-wide
+rm -f ~/.local/bin/gitb              # if installed per-user
 rm -rf ~/.gitbasher                  # remove config (optional)
 ```
 </details>

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# gitbasher installer
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/master/install.sh | bash
+#
+# Environment:
+#   GITB_VERSION   Tag to install (default: latest)
+#   GITB_DIR       Target directory (default: auto: /usr/local/bin or ~/.local/bin)
+#   GITB_NO_SUDO   Set to 1 to skip sudo and install to ~/.local/bin
+
+set -eu
+
+REPO="maxbolgarin/gitbasher"
+VERSION="${GITB_VERSION:-latest}"
+TARGET_DIR="${GITB_DIR:-}"
+NO_SUDO="${GITB_NO_SUDO:-0}"
+
+if [ -t 1 ]; then
+    RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'
+    CYAN=$'\033[36m'; BOLD=$'\033[1m'; OFF=$'\033[0m'
+else
+    RED=""; GREEN=""; YELLOW=""; CYAN=""; BOLD=""; OFF=""
+fi
+
+info()  { printf "%s==>%s %s\n" "$CYAN" "$OFF" "$*"; }
+ok()    { printf "%s✓%s %s\n"   "$GREEN" "$OFF" "$*"; }
+warn()  { printf "%s!%s %s\n"   "$YELLOW" "$OFF" "$*" >&2; }
+die()   { printf "%s✗%s %s\n"   "$RED" "$OFF" "$*" >&2; exit 1; }
+
+### --- preflight ---
+
+case "$(uname -s)" in
+    Linux|Darwin) ;;
+    *) die "Unsupported OS: $(uname -s). On Windows use WSL." ;;
+esac
+
+command -v git >/dev/null 2>&1 || die "git is required but not installed."
+
+git_version=$(git --version 2>/dev/null | awk '{print $3}')
+git_major=$(printf '%s' "$git_version" | cut -d. -f1)
+git_minor=$(printf '%s' "$git_version" | cut -d. -f2)
+if [ "${git_major:-0}" -lt 2 ] || { [ "${git_major:-0}" -eq 2 ] && [ "${git_minor:-0}" -lt 23 ]; }; then
+    warn "git ${git_version} detected; gitbasher requires git 2.23+."
+fi
+
+bash_major=${BASH_VERSINFO[0]:-0}
+if [ "$bash_major" -lt 4 ]; then
+    warn "bash ${BASH_VERSION} detected; gitbasher requires bash 4.0+."
+    case "$(uname -s)" in
+        Darwin) warn "On macOS run: brew install bash" ;;
+        Linux)  warn "Update via your package manager (e.g. apt install --only-upgrade bash)" ;;
+    esac
+fi
+
+if command -v curl >/dev/null 2>&1; then
+    DOWNLOADER="curl"
+elif command -v wget >/dev/null 2>&1; then
+    DOWNLOADER="wget"
+else
+    die "Need curl or wget to download the binary."
+fi
+
+### --- pick target dir ---
+
+# Use sudo only when really needed and available non-interactively or with a tty.
+SUDO=""
+needs_sudo() {
+    [ -d "$1" ] && [ ! -w "$1" ] && return 0
+    [ ! -d "$1" ] && parent=$(dirname "$1") && [ -d "$parent" ] && [ ! -w "$parent" ] && return 0
+    return 1
+}
+
+if [ -z "$TARGET_DIR" ]; then
+    if [ "$NO_SUDO" = "1" ]; then
+        TARGET_DIR="$HOME/.local/bin"
+    elif [ "$(id -u)" -eq 0 ]; then
+        TARGET_DIR="/usr/local/bin"
+    elif [ -w /usr/local/bin ] 2>/dev/null; then
+        TARGET_DIR="/usr/local/bin"
+    elif command -v sudo >/dev/null 2>&1; then
+        TARGET_DIR="/usr/local/bin"
+    else
+        TARGET_DIR="$HOME/.local/bin"
+    fi
+fi
+
+if needs_sudo "$TARGET_DIR"; then
+    if [ "$NO_SUDO" = "1" ]; then
+        die "Cannot write to $TARGET_DIR and GITB_NO_SUDO=1. Set GITB_DIR=\$HOME/.local/bin and rerun."
+    fi
+    if ! command -v sudo >/dev/null 2>&1; then
+        die "Cannot write to $TARGET_DIR and sudo is not available. Set GITB_DIR=\$HOME/.local/bin and rerun."
+    fi
+    SUDO="sudo"
+fi
+
+### --- resolve URL ---
+
+if [ "$VERSION" = "latest" ]; then
+    URL="https://github.com/$REPO/releases/latest/download/gitb"
+else
+    # accept "v1.2.3" or "1.2.3"
+    case "$VERSION" in v*) ;; *) VERSION="v$VERSION" ;; esac
+    URL="https://github.com/$REPO/releases/download/$VERSION/gitb"
+fi
+
+info "Installing gitbasher ($VERSION) to ${BOLD}$TARGET_DIR/gitb${OFF}"
+[ -n "$SUDO" ] && warn "Requires sudo for $TARGET_DIR — you may be prompted for your password."
+
+### --- download ---
+
+tmp=$(mktemp 2>/dev/null || mktemp -t gitb)
+trap 'rm -f "$tmp"' EXIT
+
+case "$DOWNLOADER" in
+    curl) curl -fSL --proto '=https' --tlsv1.2 -o "$tmp" "$URL" \
+              || die "Download failed: $URL" ;;
+    wget) wget -qO "$tmp" "$URL" \
+              || die "Download failed: $URL" ;;
+esac
+
+# Sanity check: the file should look like a bash script, not an HTML 404 page.
+head -c 64 "$tmp" | grep -q '^#!.*bash' \
+    || die "Downloaded file is not a bash script. Check that release '$VERSION' exists."
+
+### --- install ---
+
+$SUDO mkdir -p "$TARGET_DIR"
+$SUDO install -m 0755 "$tmp" "$TARGET_DIR/gitb"
+
+### --- verify & PATH hint ---
+
+if ! "$TARGET_DIR/gitb" --version >/dev/null 2>&1; then
+    die "Installed binary failed to run. See $TARGET_DIR/gitb"
+fi
+
+installed=$("$TARGET_DIR/gitb" --version 2>/dev/null | head -1)
+ok "Installed: $installed"
+
+case ":$PATH:" in
+    *":$TARGET_DIR:"*) ;;
+    *)
+        warn "$TARGET_DIR is not in your PATH."
+        shell_rc=""
+        case "${SHELL##*/}" in
+            zsh)  shell_rc="$HOME/.zshrc" ;;
+            bash) shell_rc="$HOME/.bashrc" ;;
+            fish) shell_rc="$HOME/.config/fish/config.fish" ;;
+        esac
+        if [ -n "$shell_rc" ]; then
+            printf "  Add it with: ${BOLD}echo 'export PATH=\"%s:\$PATH\"' >> %s${OFF}\n" "$TARGET_DIR" "$shell_rc"
+        else
+            printf "  Add ${BOLD}%s${OFF} to your PATH.\n" "$TARGET_DIR"
+        fi
+        ;;
+esac
+
+printf "\n${GREEN}${BOLD}Done.${OFF} Run ${BOLD}gitb${OFF} in any git repo to get started.\n"


### PR DESCRIPTION
## Summary
- Add `install.sh` at the repo root so users can install gitbasher with a single `curl ... | bash`.
- Replace the multi-line `sudo`+`curl`+`tee`+`chmod` recipe in the README with the new one-liner; keep npm as an alternative.

## What the installer does
- Detects OS (Linux/macOS; rejects others with a WSL hint).
- Warns on git <2.23 or bash <4.0 (with the right install hint per OS).
- Picks an install dir automatically:
  - `/usr/local/bin` if root or already writable;
  - `/usr/local/bin` with `sudo` if available (prompt goes to `/dev/tty`, so it works under `curl | bash`);
  - falls back to `~/.local/bin` otherwise.
- Downloads from `releases/latest/download/gitb` (or a pinned tag), via curl with `--proto '=https' --tlsv1.2` (wget fallback).
- Sanity-checks that the download begins with `#!...bash` so a 404 page can't be installed as the binary.
- `install -m 0755` into the target dir, then runs `gitb --version` to verify.
- Prints a PATH hint with the right rc file for `bash`/`zsh`/`fish` if the dir isn't on `PATH`.

## Env vars
- `GITB_VERSION` — pin a release (default `latest`); accepts `v1.2.3` or `1.2.3`.
- `GITB_DIR` — explicit install dir (skips auto-detect).
- `GITB_NO_SUDO=1` — never escalate; install to `~/.local/bin` instead.

## Test plan
- [x] Smoke-tested locally end-to-end via a local HTTP server: download succeeds, `install -m 0755` writes the binary, `gitb --version` prints `gitbasher v3.10.2`, PATH hint fires when target dir isn't on `PATH`.
- [x] `bash -n install.sh` clean.
- [ ] After merge: confirm `curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/main/install.sh | bash` works against the real GitHub release.
- [ ] Manual check on macOS (different `mktemp`/`install` flavors).
- [ ] Re-run with `GITB_VERSION=v3.10.2` to confirm pinned-version path.

https://claude.ai/code/session_01ABN1hSG8sxNNx4d1bjyMFD

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABN1hSG8sxNNx4d1bjyMFD)_