### PR TITLE
docs(readme): add uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ sudo chmod +x $GITB_PATH
 
 **Requirements:** `bash` 4.0+, `git` 2.23+ (macOS: `brew install bash git`).
 
+**Uninstall:**
+```bash
+npm uninstall -g gitbasher          # if installed via npm
+sudo rm -f $(which gitb)            # if installed via curl
+```
+
+Per-repo gitbasher settings live in `git config` under the `gitbasher.*` namespace and are removed with the repo. To clear global settings (AI key, default branch, scopes, etc.):
+```bash
+git config --global --remove-section gitbasher 2>/dev/null
+git config --global --unset core.editor 2>/dev/null   # only if you set it via gitb cfg editor
+```
+
 ---
 
 ## 60-second quick start


### PR DESCRIPTION
## Summary
- Add an **Uninstall** subsection right under **Install in 10 seconds** so users can find it from the same place they installed from.
- Cover both install paths: `npm uninstall -g gitbasher` and `sudo rm -f $(which gitb)` for the curl install.
- Document how to clear global gitbasher settings from `~/.gitconfig` (`git config --global --remove-section gitbasher`) for users who want a full removal.

Per-repo settings are not separately documented because they live inside the repo's `.git/config` and disappear with the repo.

## Test plan
- [x] README renders cleanly (markdown only change)
- [x] All 307 bats tests still pass

https://claude.ai/code/session_013QvP89NFrhHJe5ccMoK4Uq

---
_Generated by [Claude Code](https://claude.ai/code/session_013QvP89NFrhHJe5ccMoK4Uq)_