### PR TITLE
refactor(wip): merge wip/unwip into single wip up/down command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 gitb commit push       # stage, write a conventional commit, push — in one flow
 gitb c ai              # AI-generated commit message
 gitb sync              # fetch main + rebase your branch
-gitb wip               # snapshot WIP, push, keep moving
+gitb wip up            # stash WIP, push backup branch, clean working tree
 gitb undo              # roll back your last commit / amend / merge / rebase / stash
 ```
 
@@ -85,7 +85,7 @@ Every command has a short alias (`gitb c`, `gitb p`, `gitb pu`, `gitb b`, `gitb 
 - [Common workflows](#common-workflows)
 - [Command reference](#command-reference)
   - [commit](#gitb-commit) · [push](#gitb-push) · [pull](#gitb-pull) · [branch](#gitb-branch) · [tag](#gitb-tag) · [merge](#gitb-merge) · [rebase](#gitb-rebase)
-  - [cherry](#gitb-cherry) · [sync](#gitb-sync) · [wip / unwip](#gitb-wip--unwip) · [fixup](#gitb-fixup) · [undo](#gitb-undo) · [reset](#gitb-reset) · [stash](#gitb-stash)
+  - [cherry](#gitb-cherry) · [sync](#gitb-sync) · [wip](#gitb-wip) · [fixup](#gitb-fixup) · [undo](#gitb-undo) · [reset](#gitb-reset) · [stash](#gitb-stash)
   - [hook](#gitb-hook) · [config](#gitb-config) · [log](#gitb-log) · [info commands](#info-commands)
 - [Configuration](#configuration)
 - [Troubleshooting](#troubleshooting)
@@ -119,7 +119,7 @@ Every command has a short alias (`gitb c`, `gitb p`, `gitb pu`, `gitb b`, `gitb 
 | **Branches** | `branch` (`b`), `prev` (`-`) | List / switch / create-from-current / create-from-updated-main / delete (orphaned, merged, gone) / recent / previous / checkout-tag |
 | **Integration** | `merge` (`m`), `rebase` (`r`), `cherry` (`ch`) | Merge into current / into main / from remote · rebase onto main / interactive / autosquash / fastautosquash / pull-commits · cherry-pick by hash, range, or interactive |
 | **Tags & releases** | `tag` (`t`) | Lightweight, annotated, from-commit, push, push-all, delete, delete-all, list, fetch-remote |
-| **Save & rollback** | `wip` / `unwip`, `undo` (`un`), `reset` (`res`), `stash` (`s`), `fixup` (`fx`) | One-command WIP snapshot/restore · undo last commit/amend/merge/rebase/stash · interactive reset · full stash menu · fixup + autosquash in a single step |
+| **Save & rollback** | `wip` (`up`/`down`), `undo` (`un`), `reset` (`res`), `stash` (`s`), `fixup` (`fx`) | Stash WIP + push backup branch, restore in one step · undo last commit/amend/merge/rebase/stash · interactive reset · full stash menu · fixup + autosquash in a single step |
 | **Inspect** | `status` (`st`), `log` (`l`), `reflog` (`rl`), `last-commit` (`lc`), `last-ref` (`lr`) | Pretty repo status, multi-mode log + search, reflog viewer, quick last-commit / last-ref summary |
 | **Hooks** | `hook` (`ho`) | List / create from templates / edit / toggle / remove / test / show — for every git hook |
 | **Repo setup** | `init` (`i`), `origin` (`or`, `o`, `remote`) | `git init` from gitbasher · add/change/rename/remove the remote origin |
@@ -219,9 +219,10 @@ gitb sync merge      # use merge instead of rebase
 
 ### Save WIP across machines / branches
 ```bash
-gitb wip             # add . + WIP commit + push
+gitb wip up          # stash changes + push backup to origin/wip/<branch>
 # … on another machine …
-gitb pu && gitb unwip   # restore changes, drop the WIP commit
+gitb pull            # fetch the wip/<branch>
+gitb wip down        # pop the wip stash and remove the remote backup
 ```
 
 ### Hotfix
@@ -278,8 +279,7 @@ gitb b -             # back to previous branch (like cd -)
 | [`rebase`](#gitb-rebase) | `r` `re` `base` | Rebase onto main / interactive / autosquash / pull-commits |
 | [`cherry`](#gitb-cherry) | `ch` `cp` | Cherry-pick by hash, range, or interactive picker |
 | [`sync`](#gitb-sync) | `sy` | Fetch main + rebase (or merge) current branch, optional push |
-| [`wip`](#gitb-wip--unwip) | `w` | Stage all + WIP commit + push (one keystroke save) |
-| [`unwip`](#gitb-wip--unwip) | `uw` | Undo a WIP commit and restore the changes |
+| [`wip`](#gitb-wip) | `w` | Stash all + backup to remote (`up`) / restore (`down`) |
 | [`fixup`](#gitb-fixup) | `fx` | Create fixup commit and autosquash in one step |
 | [`undo`](#gitb-undo) | `un` | Undo last commit / amend / merge / rebase / stash |
 | [`reset`](#gitb-reset) | `res` | Friendly `git reset` with undo support |
@@ -427,15 +427,15 @@ Fetch the default branch and update your current branch. Useful mid-feature.
 | `merge` | `m` | Use merge instead of rebase |
 | `mergep` | `mp` `pm` | Merge + push |
 
-### `gitb wip` / `unwip`
+### `gitb wip`
 
-Snapshot work-in-progress in one keystroke; restore it later.
+Stash work-in-progress as a single `wip` stash and back it up to a remote `wip/<branch>` branch so it survives between machines. Restore later with `wip down`.
 
-| Command | Mode | Description |
-|---------|------|-------------|
-| `gitb wip` | `<empty>` | Stage all, WIP commit, push |
-| `gitb wip` | `nopush` (`np` `n`) | Stage all + WIP commit, no push |
-| `gitb unwip` | | Undo the WIP commit, restore the changes to the working tree |
+| Command | Mode | Aliases | Description |
+|---------|------|---------|-------------|
+| `gitb wip up` | | `u` | Stash all changes (incl. untracked) as `wip: <branch>` and force-push the stash to `origin/wip/<branch>` |
+| `gitb wip up nopush` | | `np` `n` | Stash only, skip the remote backup |
+| `gitb wip down` | | `d` | Pop the most recent wip stash for the current branch and delete the remote backup |
 
 ### `gitb fixup`
 

--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -17,8 +17,7 @@ function print_help {
     msg="$msg\nrebase_r|re|base_Rebase current branch"
     msg="$msg\ncherry_ch|cp_Cherry-pick commits from other branches"
     msg="$msg\nsync_sy_Sync current branch with $main_branch (fetch + rebase/merge)"
-    msg="$msg\nwip_w_Quick WIP commit + push for saving work in progress"
-    msg="$msg\nunwip_uw_Undo a WIP commit and restore changes"
+    msg="$msg\nwip_w_Stash work-in-progress and back it up to remote (up/down)"
     msg="$msg\nfixup_fx_Create fixup commit + autosquash rebase in one step"
     msg="$msg\nundo_un_Quick undo for commit, amend, merge, rebase, or stash"
     msg="$msg\nreset_res_Easy to use git reset"
@@ -92,10 +91,7 @@ case "$1" in
         sync_script $2
     ;;
     wip|w)
-        wip_script $2
-    ;;
-    unwip|uw)
-        unwip_script $2
+        wip_script $2 $3
     ;;
     branch|b|br|bran)         
         branch_script $2

--- a/scripts/wip.sh
+++ b/scripts/wip.sh
@@ -1,144 +1,205 @@
 #!/usr/bin/env bash
 
-### Script for quick work-in-progress save and restore
-# Saves all changes as a WIP commit, optionally pushes
+### Script for quick work-in-progress save and restore.
+# wip up   — stash all changes as "wip" and push a backup branch to origin
+# wip down — pop the wip stash for the current branch (and remove the remote backup)
 # Use this script only with gitbasher
 
 
-### Main function for wip
-# $1: mode
-    # <empty>: stage all, WIP commit, push
-    # nopush: stage all, WIP commit, skip push
-function wip_script {
+### Build the stash message used for the wip stash on the current branch
+function wip_stash_message {
+    echo "wip: ${current_branch}"
+}
+
+
+### Build the remote backup branch name for the current branch
+function wip_remote_branch {
+    echo "wip/${current_branch}"
+}
+
+
+### Find the most recent wip stash for the current branch
+# Sets:
+#     wip_stash_ref - e.g. 'stash@{2}', or empty if not found
+function find_wip_stash {
+    wip_stash_ref=""
+    local target
+    target="$(wip_stash_message)"
+    while IFS= read -r line; do
+        local ref="${line%%:*}"
+        local subject="${line#*: }"
+        if [ "$subject" = "On ${current_branch}: ${target}" ] || [ "$subject" = "WIP on ${current_branch}: ${target}" ] || [[ "$line" == *"${target}"* ]]; then
+            wip_stash_ref="$ref"
+            return 0
+        fi
+    done < <(git stash list)
+    [ -n "$wip_stash_ref" ]
+}
+
+
+### Subcommand: stash all changes and (optionally) push a backup to origin
+# $1: nopush mode flag (nopush|np|n)
+function wip_up {
+    local nopush=""
     case "$1" in
         nopush|np|n)    nopush="true";;
-        help|h)         help="true";;
-        *)
-            wrong_mode "wip" $1
+        "")             ;;
+        *)              wrong_mode "wip up" "$1";;
     esac
 
-    ### Print header
-    header_msg="GIT WIP"
-    if [ -n "${nopush}" ]; then
+    local header_msg="GIT WIP UP"
+    if [ -n "$nopush" ]; then
         header_msg="$header_msg (NO PUSH)"
     fi
-
     echo -e "${YELLOW}${header_msg}${ENDCOLOR}"
     echo
 
-
-    if [ -n "$help" ]; then
-        echo -e "usage: ${YELLOW}gitb wip <mode>${ENDCOLOR}"
-        echo
-        msg="${YELLOW}Mode${ENDCOLOR}_${GREEN}Aliases${ENDCOLOR}_\t${BLUE}Description${ENDCOLOR}"
-        msg="$msg\n${BOLD}<empty>${ENDCOLOR}_ _Stage all changes, create WIP commit, and push"
-        msg="$msg\n${BOLD}nopush${ENDCOLOR}_np|n_Stage all changes and create WIP commit without pushing"
-        msg="$msg\n${BOLD}help${ENDCOLOR}_h_Show this help"
-        echo -e "$(echo -e "$msg" | column -ts'_')"
-        echo
-        echo -e "Use ${YELLOW}gitb unwip${ENDCOLOR} to undo the WIP commit and restore your changes"
-        exit
-    fi
-
-
-    ### Check if there are changes to save
     if git diff --quiet && git diff --cached --quiet && [ -z "$(git ls-files --others --exclude-standard)" ]; then
         echo -e "${GREEN}No changes to save${ENDCOLOR}"
         exit
     fi
 
-    ### Show what will be saved
     echo -e "${YELLOW}Changes to save:${ENDCOLOR}"
     git_status
     echo
 
-    ### Stage all changes
-    git add -A
+    local message
+    message="$(wip_stash_message)"
 
-    ### Create WIP commit with branch context
-    wip_message="wip: ${current_branch} work in progress"
+    local stash_output stash_code
+    stash_output=$(git stash push --include-untracked --message "$message" 2>&1)
+    stash_code=$?
 
-    result=$(git commit -m "$wip_message" 2>&1)
-    commit_code=$?
-
-    if [ $commit_code -ne 0 ]; then
-        echo -e "${RED}Cannot create WIP commit! Error message:${ENDCOLOR}"
-        echo "$result"
-        git reset HEAD 2>/dev/null
-        exit $commit_code
+    if [ $stash_code -ne 0 ]; then
+        echo -e "${RED}Cannot stash changes! Error message:${ENDCOLOR}"
+        echo "$stash_output"
+        exit $stash_code
     fi
 
-    commit_hash=$(git rev-parse HEAD)
-    echo -e "${GREEN}WIP saved!${ENDCOLOR}"
-    echo -e "${BLUE}[$current_branch ${commit_hash::7}]${ENDCOLOR} $wip_message"
+    local stash_hash
+    stash_hash=$(git rev-parse --short stash@{0} 2>/dev/null)
+    echo -e "${GREEN}WIP stashed!${ENDCOLOR} ${BLUE}[${stash_hash}]${ENDCOLOR} $message"
     echo
 
-    ### Push if not in nopush mode
-    if [ -z "$nopush" ] && [ -n "$origin_name" ]; then
-        echo -e "${YELLOW}Pushing WIP...${ENDCOLOR}"
-        echo
-        push_output=$(git push ${origin_name} ${current_branch} 2>&1)
-        push_code=$?
+    if [ -n "$nopush" ]; then
+        echo -e "Restore with: ${YELLOW}gitb wip down${ENDCOLOR}"
+        return
+    fi
 
-        if [ $push_code -eq 0 ]; then
-            echo -e "${GREEN}WIP pushed to ${origin_name}/${current_branch}${ENDCOLOR}"
-        else
-            echo -e "${YELLOW}Could not push WIP (you can push manually later)${ENDCOLOR}"
-            echo "$push_output"
-        fi
-    elif [ -z "$nopush" ] && [ -z "$origin_name" ]; then
+    if [ -z "$origin_name" ]; then
         echo -e "${YELLOW}No remote configured, skipping push${ENDCOLOR}"
+        echo
+        echo -e "Restore with: ${YELLOW}gitb wip down${ENDCOLOR}"
+        return
+    fi
+
+    local remote_branch
+    remote_branch="$(wip_remote_branch)"
+    echo -e "${YELLOW}Pushing WIP backup to ${origin_name}/${remote_branch}...${ENDCOLOR}"
+    local push_output push_code
+    push_output=$(git push --force "${origin_name}" "stash@{0}:refs/heads/${remote_branch}" 2>&1)
+    push_code=$?
+
+    if [ $push_code -eq 0 ]; then
+        echo -e "${GREEN}WIP pushed to ${origin_name}/${remote_branch}${ENDCOLOR}"
+    else
+        echo -e "${YELLOW}Could not push WIP backup (you can push manually later)${ENDCOLOR}"
+        echo "$push_output"
     fi
 
     echo
-    echo -e "Restore with: ${YELLOW}gitb unwip${ENDCOLOR}"
+    echo -e "Restore with: ${YELLOW}gitb wip down${ENDCOLOR}"
 }
 
 
-### Main function for unwip
-function unwip_script {
-    if [ "$1" == "help" ] || [ "$1" == "h" ]; then
-        echo -e "${YELLOW}GIT UNWIP${ENDCOLOR}"
-        echo
-        echo -e "usage: ${YELLOW}gitb unwip${ENDCOLOR}"
-        echo
-        echo -e "Undoes the last WIP commit, restoring your changes to the working tree."
-        echo -e "Changes will be unstaged so you can re-organize them before committing."
-        exit
-    fi
+### Subcommand: pop the most recent wip stash for the current branch
+function wip_down {
+    case "$1" in
+        "")     ;;
+        *)      wrong_mode "wip down" "$1";;
+    esac
 
-    echo -e "${YELLOW}GIT UNWIP${ENDCOLOR}"
+    echo -e "${YELLOW}GIT WIP DOWN${ENDCOLOR}"
     echo
 
-    ### Check if the last commit is a WIP commit
-    last_message=$(git log -n 1 --pretty="%s" 2>/dev/null)
-
-    if [[ "$last_message" != wip:* ]]; then
-        echo -e "${RED}Last commit is not a WIP commit${ENDCOLOR}"
-        echo -e "Last commit: ${YELLOW}$last_message${ENDCOLOR}"
+    if ! find_wip_stash; then
+        echo -e "${RED}No WIP stash found for branch ${current_branch}${ENDCOLOR}"
         echo
-        echo -e "Use ${YELLOW}gitb undo${ENDCOLOR} to undo a regular commit"
+        echo -e "Save one first with: ${YELLOW}gitb wip up${ENDCOLOR}"
         exit 1
     fi
 
-    ### Show the WIP commit
-    wip_commit=$(git log -n 1 --pretty="%s | ${YELLOW}%h${ENDCOLOR} | ${GREEN}%cr${ENDCOLOR}")
-    echo -e "${YELLOW}WIP commit to undo:${ENDCOLOR}"
-    echo -e "\t$wip_commit"
+    local stash_summary
+    stash_summary=$(git stash list --pretty="%gd | %s | ${GREEN_ES}%cr${ENDCOLOR_ES}" "$wip_stash_ref" 2>/dev/null | head -n 1)
+    echo -e "${YELLOW}WIP stash to restore:${ENDCOLOR}"
+    echo -e "\t${stash_summary}"
     echo
 
-    ### Reset the WIP commit (mixed to unstage everything)
-    reset_output=$(git reset HEAD~1 2>&1)
-    reset_code=$?
+    local pop_output pop_code
+    pop_output=$(git stash pop "$wip_stash_ref" 2>&1)
+    pop_code=$?
 
-    if [ $reset_code -ne 0 ]; then
-        echo -e "${RED}Cannot undo WIP commit! Error message:${ENDCOLOR}"
-        echo "$reset_output"
-        exit $reset_code
+    if [ $pop_code -ne 0 ]; then
+        echo -e "${RED}Cannot restore WIP! Error message:${ENDCOLOR}"
+        echo "$pop_output"
+        exit $pop_code
     fi
 
-    echo -e "${GREEN}WIP commit undone!${ENDCOLOR}"
+    echo -e "${GREEN}WIP restored!${ENDCOLOR}"
     echo
     echo -e "${YELLOW}Restored changes:${ENDCOLOR}"
     git_status
+
+    if [ -z "$origin_name" ]; then
+        return
+    fi
+
+    local remote_branch
+    remote_branch="$(wip_remote_branch)"
+    if ! git ls-remote --exit-code --heads "$origin_name" "$remote_branch" >/dev/null 2>&1; then
+        return
+    fi
+
+    echo
+    echo -e "${YELLOW}Removing remote WIP backup ${origin_name}/${remote_branch}...${ENDCOLOR}"
+    local delete_output delete_code
+    delete_output=$(git push "$origin_name" --delete "$remote_branch" 2>&1)
+    delete_code=$?
+    if [ $delete_code -eq 0 ]; then
+        echo -e "${GREEN}Remote WIP backup removed${ENDCOLOR}"
+    else
+        echo -e "${YELLOW}Could not remove remote WIP backup (you can delete it manually later)${ENDCOLOR}"
+        echo "$delete_output"
+    fi
+}
+
+
+### Print help for the wip command
+function wip_help {
+    echo -e "${YELLOW}GIT WIP${ENDCOLOR}"
+    echo
+    echo -e "usage: ${YELLOW}gitb wip <up|down>${ENDCOLOR}"
+    echo
+    msg="${YELLOW}Mode${ENDCOLOR}_${GREEN}Aliases${ENDCOLOR}_\t${BLUE}Description${ENDCOLOR}"
+    msg="$msg\n${BOLD}up${ENDCOLOR}_u_Stash all changes as 'wip' and push a backup branch to remote"
+    msg="$msg\n${BOLD}up nopush${ENDCOLOR}_u np|n_Stash all changes as 'wip' without pushing"
+    msg="$msg\n${BOLD}down${ENDCOLOR}_d_Restore the WIP stash for the current branch and remove the remote backup"
+    msg="$msg\n${BOLD}help${ENDCOLOR}_h_Show this help"
+    echo -e "$(echo -e "$msg" | column -ts'_')"
+    echo
+    echo -e "WIP saves work-in-progress as a git stash and pushes a backup to"
+    echo -e "${YELLOW}${origin_name:-origin}/wip/<branch>${ENDCOLOR} so you can recover it from anywhere."
+}
+
+
+### Main function for wip
+# $1: subcommand (up|down|help)
+# $2: subcommand mode (e.g. nopush for up)
+function wip_script {
+    case "$1" in
+        up|u)           wip_up "$2";;
+        down|d)         wip_down "$2";;
+        help|h|"")      wip_help;;
+        *)              wrong_mode "wip" "$1";;
+    esac
 }


### PR DESCRIPTION
## Summary

Replaces the old `wip` (commit + push) / `unwip` (reset HEAD~1) pair with a single, cleaner stash-based command:

- **`gitb wip up`** (alias `u`) — stashes all changes (incl. untracked) with the message `wip: <branch>` and force-pushes the stash to `origin/wip/<branch>` as a remote backup. Working tree ends up clean.
- **`gitb wip up nopush`** (`np`, `n`) — stash only, no remote push.
- **`gitb wip down`** (alias `d`) — finds the most recent `wip: <branch>` stash for the current branch, pops it, and best-effort deletes the remote `wip/<branch>` backup.
- **`gitb wip` / `gitb wip help`** — shows usage.

Why this is better than the old design:
- No more polluting the commit history with `wip:` commits — uses git's stash mechanism instead.
- Untracked files are saved (the old `git add -A` + commit also did, but stash with `--include-untracked` is the proper tool).
- Pushing the stash to `origin/wip/<branch>` gives you a remote backup you can recover from any machine, while the local working tree returns to a clean state immediately.
- One command, two clear directions: `up` to save, `down` to restore.

## Changes
- `scripts/wip.sh` — rewritten with `wip_up`, `wip_down`, `wip_help`, dispatched from `wip_script`.
- `scripts/base.sh` — drops the `unwip` case, routes `wip|w` with two args, updates the help table line.
- `README.md` — updates TOC, hero example, "all features" table, command index, common workflow, and the dedicated `gitb wip` section.

## Test plan
- [x] Syntax-check (`bash -n`) on `scripts/wip.sh` and `scripts/base.sh`.
- [x] Smoke test in a sandbox repo with a bare remote:
  - [x] `wip up` with changes → stashes, pushes `wip/main`, working tree clean.
  - [x] `wip down` → pops the stash, deletes the remote backup, restores changes.
  - [x] `wip down` with no stash → clear error and non-zero exit.
  - [x] `wip up nopush` → stashes locally, no remote push.
- [ ] Manual end-to-end test against a real GitHub remote.
- [ ] Verify behavior when `wip down` is run on a different machine after fetching `origin/wip/<branch>` (cross-machine handoff).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jipzgj56fQ6vFyuo9PrQjg)_