### PR TITLE
fix(merge): treat already-committed merge as success

### DIFF
--- a/scripts/merge.sh
+++ b/scripts/merge.sh
@@ -508,7 +508,13 @@ function resolve_conflicts {
 function merge_commit {
     merge_error="false"
 
-   
+    ### If merge was already committed externally, treat as success
+    if [ ! -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]; then
+        echo
+        echo -e "${GREEN}Merge already committed${ENDCOLOR}"
+        return
+    fi
+
     ### Check if there are files with conflicts
     files_with_conflicts_one_line="$(echo "$2" | tr '\n' ' ' | sed 's/ $//')"
     files_with_conflicts_new="$(git --no-pager grep -l --name-only -E "[<=>]{7} HEAD" $files_with_conflicts_one_line)"
@@ -527,7 +533,7 @@ function merge_commit {
     ### Add all files that were in conflict to commit (they should be resolved now)
     echo
     echo -e "${YELLOW}Adding resolved files to commit...${ENDCOLOR}"
-    
+
     # Add all modified files (this includes the resolved conflict files)
     git add -u
 
@@ -536,10 +542,10 @@ function merge_commit {
         commit_message="$3"
         result=$(git commit -m "$commit_message" 2>&1)
         commit_status=$?
-        if [[ $result != *"not staged for commit"* ]]; then
+        if [[ $result != *"not staged for commit"* ]] && [[ $result != *"nothing to commit"* ]]; then
             check_code $commit_status "$result" "creating default merge commit"
-        fi  
-        
+        fi
+
 
     ### 2. Commit with entered message
     else
@@ -548,8 +554,8 @@ function merge_commit {
         trap 'rm -f "$commitmsg_file"' EXIT INT TERM
         echo """
 ####
-#### Write a message about merge from '$5/$4' into '$4'. Lines starting with '#' will be ignored. 
-#### 
+#### Write a message about merge from '$5/$4' into '$4'. Lines starting with '#' will be ignored.
+####
 #### On branch $4
 #### Changes to be commited:
 ${staged_with_tab}
@@ -571,15 +577,16 @@ ${staged_with_tab}
                 rm -f "$commitmsg_file"
                 merge_error="true"
                 exit
-            fi    
+            fi
         done
 
         rm -f "$commitmsg_file"
-        
-        result=$(git commit -m """$commit_message""" 2>&1)
 
-        if [[ $result != *"not staged for commit"* ]]; then
-            check_code $? "$result" "creating merge commit"
-        fi  
+        result=$(git commit -m """$commit_message""" 2>&1)
+        commit_status=$?
+
+        if [[ $result != *"not staged for commit"* ]] && [[ $result != *"nothing to commit"* ]]; then
+            check_code $commit_status "$result" "creating merge commit"
+        fi
     fi
 }


### PR DESCRIPTION
## Summary

When running `gitb merge tm` (or any merge), if the user resolves conflicts and creates the merge commit externally before pressing `1`/`2` in the resolve-conflicts prompt, the script attempted another `git commit` that failed with `nothing to commit, working tree clean` and surfaced a misleading `Error during creating default merge commit!` message — even though the merge actually succeeded.

## Changes

- `scripts/merge.sh` — `merge_commit()`:
  - Detect already-committed merges by checking for `MERGE_HEAD` at function entry and return success immediately.
  - Also tolerate `nothing to commit` in the `git commit` result as a safety net.
  - Capture `$?` into `commit_status` for option 2 (entered message) — previously `$?` was the test exit code, not the commit's.

## Reproduction (before fix)

```
> gitb merge tm
... conflicts in scripts/common.sh, scripts/push.sh, scripts/tag.sh ...
# user resolves conflicts and runs `git commit` manually
# user presses 1 in the gitb prompt
Adding resolved files to commit...

Error during creating default merge commit!
On branch main
Your branch and 'origin/main' have diverged, ...
nothing to commit, working tree clean
```

## Test plan

- [ ] Trigger a merge conflict via `gitb merge tm`, resolve manually, run `git commit` outside the script, then press `1` — expect "Merge already committed" and clean exit.
- [ ] Trigger a merge conflict, resolve manually, leave staged but uncommitted, then press `1` — expect normal default-message merge commit.
- [ ] Repeat the second case with option `2` (entered message) — expect normal merge commit.

https://claude.ai/code/session_016bJF4g1bHQpmgs6bJWeEcV

---
_Generated by [Claude Code](https://claude.ai/code/session_016bJF4g1bHQpmgs6bJWeEcV)_