### PR TITLE
feat(install): default to ~/.local/bin, add --sudo flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ gitb undo              # roll back your last commit / amend / merge / rebase / s
 curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/main/install.sh | bash
 ```
 
-The installer auto-detects your OS, picks `/usr/local/bin` (with `sudo` if needed) or falls back to `~/.local/bin`, downloads the latest release, and prints a PATH hint if required. Override with env vars:
+By default the installer drops `gitb` into `~/.local/bin` — no `sudo`, no password prompt. It downloads the latest release and prints a PATH hint if needed. Opt into a system-wide install or override the location:
 
 ```bash
-GITB_DIR=~/.local/bin   curl ... | bash    # custom location, no sudo
+curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/main/install.sh | bash -s -- --sudo   # /usr/local/bin (sudo)
+GITB_DIR=/opt/bin       curl ... | bash    # custom location
 GITB_VERSION=v3.10.2    curl ... | bash    # pin a release
-GITB_NO_SUDO=1          curl ... | bash    # never use sudo
 ```
 
 **npm:**
@@ -48,7 +48,8 @@ npm install -g gitbasher
 **Uninstall:**
 ```bash
 npm uninstall -g gitbasher          # if installed via npm
-sudo rm -f $(which gitb)            # if installed via curl
+rm -f ~/.local/bin/gitb             # if installed via curl (default location)
+sudo rm -f /usr/local/bin/gitb      # if installed via curl with --sudo
 ```
 
 Per-repo gitbasher settings live in `git config` under the `gitbasher.*` namespace and are removed with the repo. To clear global settings (AI key, default branch, scopes, etc.):
@@ -614,7 +615,10 @@ Reinstall via npm (`npm install -g gitbasher`) or curl (see [install](#install-i
 <details>
 <summary><b>Permission denied during install</b></summary>
 
-Use `sudo`, or install to `~/.local/bin` and add it to `PATH`.
+The default install goes to `~/.local/bin` (no sudo). For a system-wide install pass `--sudo`:
+```bash
+curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/main/install.sh | bash -s -- --sudo
+```
 </details>
 
 <details>

--- a/install.sh
+++ b/install.sh
@@ -3,18 +3,40 @@
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/master/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/maxbolgarin/gitbasher/master/install.sh | bash -s -- --sudo
+#
+# Flags:
+#   --sudo         Install system-wide to /usr/local/bin (uses sudo if needed)
 #
 # Environment:
 #   GITB_VERSION   Tag to install (default: latest)
-#   GITB_DIR       Target directory (default: auto: /usr/local/bin or ~/.local/bin)
-#   GITB_NO_SUDO   Set to 1 to skip sudo and install to ~/.local/bin
+#   GITB_DIR       Target directory (default: ~/.local/bin, or /usr/local/bin with --sudo)
+#   GITB_SUDO      Set to 1 for system-wide install (same as --sudo)
+#   GITB_NO_SUDO   Set to 1 to forbid sudo even when needed (kept for back-compat)
 
 set -eu
 
 REPO="maxbolgarin/gitbasher"
 VERSION="${GITB_VERSION:-latest}"
 TARGET_DIR="${GITB_DIR:-}"
+USE_SUDO="${GITB_SUDO:-0}"
 NO_SUDO="${GITB_NO_SUDO:-0}"
+
+for arg in "$@"; do
+    case "$arg" in
+        --sudo)    USE_SUDO=1 ;;
+        --no-sudo) NO_SUDO=1 ;;
+        -h|--help)
+            sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *) printf "Unknown argument: %s\n" "$arg" >&2; exit 2 ;;
+    esac
+done
+
+if [ "$USE_SUDO" = "1" ] && [ "$NO_SUDO" = "1" ]; then
+    printf "Conflicting options: --sudo and --no-sudo (or GITB_SUDO/GITB_NO_SUDO).\n" >&2
+    exit 2
+fi
 
 if [ -t 1 ]; then
     RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'
@@ -72,13 +94,7 @@ needs_sudo() {
 }
 
 if [ -z "$TARGET_DIR" ]; then
-    if [ "$NO_SUDO" = "1" ]; then
-        TARGET_DIR="$HOME/.local/bin"
-    elif [ "$(id -u)" -eq 0 ]; then
-        TARGET_DIR="/usr/local/bin"
-    elif [ -w /usr/local/bin ] 2>/dev/null; then
-        TARGET_DIR="/usr/local/bin"
-    elif command -v sudo >/dev/null 2>&1; then
+    if [ "$USE_SUDO" = "1" ] || [ "$(id -u)" -eq 0 ]; then
         TARGET_DIR="/usr/local/bin"
     else
         TARGET_DIR="$HOME/.local/bin"
@@ -87,7 +103,7 @@ fi
 
 if needs_sudo "$TARGET_DIR"; then
     if [ "$NO_SUDO" = "1" ]; then
-        die "Cannot write to $TARGET_DIR and GITB_NO_SUDO=1. Set GITB_DIR=\$HOME/.local/bin and rerun."
+        die "Cannot write to $TARGET_DIR without sudo. Drop --no-sudo or pick a writable GITB_DIR (e.g. \$HOME/.local/bin)."
     fi
     if ! command -v sudo >/dev/null 2>&1; then
         die "Cannot write to $TARGET_DIR and sudo is not available. Set GITB_DIR=\$HOME/.local/bin and rerun."


### PR DESCRIPTION
## Summary
- Default install location is now `~/.local/bin` (XDG standard, no sudo prompt). Removes the surprise `sudo` prompt from the curl|bash one-liner.
- New `--sudo` flag (and `GITB_SUDO=1` env var) opts into a system-wide `/usr/local/bin` install.
- `GITB_NO_SUDO=1` and `GITB_DIR` keep working; root users still default to `/usr/local/bin`.
- README updated: install one-liner, uninstall paths, and "permission denied" troubleshooting reflect the new default.

## Test plan
- [x] `bash -n install.sh` passes
- [x] Default run as non-root → picks `~/.local/bin`
- [x] `--sudo` → picks `/usr/local/bin`
- [x] `GITB_DIR=/custom` → uses custom path
- [x] Unknown flag exits 2
- [x] `--sudo --no-sudo` rejected with clear error
- [ ] End-to-end: download a real release into `~/.local/bin` on a fresh Linux user account
- [ ] End-to-end: `--sudo` install on macOS

https://claude.ai/code/session_01MqWRkc76mhfrKXqxC2xnN9

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqWRkc76mhfrKXqxC2xnN9)_