### PR TITLE
feat(pull,sync): add dry-run mode for previewing incoming commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ gitb b -             # back to previous branch (like cd -)
 |---------|---------|-------------|
 | [`commit`](#gitb-commit) | `c` `co` `com` | Create commits (interactive, fast, AI, split, fixup, amend, revert, …) |
 | [`push`](#gitb-push) | `p` `ps` `pus` | Push with conflict handling, force, or list-only |
-| [`pull`](#gitb-pull) | `pu` `pl` `pul` | Smart pull: rebase / merge / ff / fetch-only / interactive |
+| [`pull`](#gitb-pull) | `pu` `pl` `pul` | Smart pull: rebase / merge / ff / fetch-only / interactive / dry-run |
 | [`branch`](#gitb-branch) | `b` `br` `bran` | Switch / list / create / delete / recent / gone / checkout-tag |
 | [`tag`](#gitb-tag) | `t` `tg` | Create, push, list, delete tags (lightweight & annotated) |
 | [`merge`](#gitb-merge) | `m` `me` | Merge into current, into main, or from remote |
@@ -398,6 +398,7 @@ gitb b -             # back to previous branch (like cd -)
 | `merge` | `m` | Always create merge commit |
 | `rebase` | `r` | Rebase current onto remote |
 | `interactive` | `ri` `rs` | Interactive rebase + autosquash |
+| `dry` | `d` `dr` | Preview incoming commits without modifying local refs |
 
 ### `gitb branch`
 
@@ -471,6 +472,7 @@ Fetch the default branch and update your current branch. Useful mid-feature.
 | `push` | `p` | …then force-push |
 | `merge` | `m` | Use merge instead of rebase |
 | `mergep` | `mp` `pm` | Merge + push |
+| `dry` | `d` `dr` | Preview commits sync would bring in from main without modifying local refs |
 
 ### `gitb wip`
 

--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -24,6 +24,7 @@ function pull_script {
         merge|m)            merge="true";;
         rebase|r)           rebase="true";;
         interactive|ri|rs)  rebase="true"; interactive="true";;
+        dry|d|dr)           dry="true";;
         help|h)             help="true";;
         *)
             wrong_mode "pull" $1
@@ -32,7 +33,9 @@ function pull_script {
 
     ### Print header
     header_msg="GIT PULL"
-    if [ -n "${fetch}" ]; then
+    if [ -n "${dry}" ]; then
+        header_msg="$header_msg DRY RUN"
+    elif [ -n "${fetch}" ]; then
         if [ -n "${all}" ]; then
             header_msg="$header_msg FETCH ALL"
         else
@@ -68,6 +71,7 @@ function pull_script {
         msg="$msg\n${BOLD}merge${ENDCOLOR}_m_Fetch current branch and then merge it"
         msg="$msg\n${BOLD}rebase${ENDCOLOR}_r_Fetch current branch and then rebase"
         msg="$msg\n${BOLD}interactive${ENDCOLOR}_ri|rs_Fetch current branch and then rebase in interactive mode with --autosquash"
+        msg="$msg\n${BOLD}dry${ENDCOLOR}_d|dr_Preview incoming commits from remote without modifying local refs"
         msg="$msg\n${BOLD}help${ENDCOLOR}_h_Show this help"
         echo -e "$(echo -e "$msg" | column -ts'_')"
         exit
@@ -84,6 +88,68 @@ function pull_script {
         echo -e "${RED}No git remote configured.${ENDCOLOR}"
         echo -e "Use ${BLUE}git remote add origin <url>${ENDCOLOR} to set it up first."
         exit 1
+    fi
+
+    if [ -n "$dry" ]; then
+        echo -e "${YELLOW}Checking '$origin_name/$current_branch' for incoming commits...${ENDCOLOR}"
+        echo
+
+        ### Snapshot the remote-tracking ref so we can restore it after the fetch.
+        ### git fetch always honors the configured refs/heads/*:refs/remotes/origin/* refspec,
+        ### even when an explicit refspec is also passed, so we have to roll back manually.
+        remote_tracking_ref="refs/remotes/$origin_name/$current_branch"
+        saved_ref=$(git rev-parse --verify --quiet "$remote_tracking_ref")
+
+        dry_output=$(git fetch --no-tags "$origin_name" "$current_branch" 2>&1)
+        dry_code=$?
+
+        ### Restore the remote-tracking ref to its pre-dry-run value
+        if [ -n "$saved_ref" ]; then
+            git update-ref "$remote_tracking_ref" "$saved_ref" 2>/dev/null
+        else
+            git update-ref -d "$remote_tracking_ref" 2>/dev/null
+        fi
+
+        if [ $dry_code != 0 ]; then
+            if [[ "$dry_output" == *"couldn't find remote ref"* ]]; then
+                echo -e "${YELLOW}There is no '$current_branch' in $origin_name${ENDCOLOR}"
+                exit
+            fi
+            echo -e "${RED}Cannot fetch! Error message:${ENDCOLOR}"
+            echo -e "$dry_output"
+            exit $dry_code
+        fi
+
+        ### FETCH_HEAD now points at the just-fetched tip — diff against HEAD
+        behind_commits=$(commit_list 999 "tab" "HEAD..FETCH_HEAD")
+        ahead_commits=$(commit_list 999 "tab" "FETCH_HEAD..HEAD")
+
+        if [ -z "$behind_commits" ] && [ -z "$ahead_commits" ]; then
+            echo -e "${GREEN}Already up to date${ENDCOLOR}"
+            echo
+            echo -e "${BLUE}Dry run only — no local refs were modified${ENDCOLOR}"
+            exit
+        fi
+
+        if [ -n "$behind_commits" ]; then
+            behind_count=$(echo -e "$behind_commits" | wc -l | sed 's/^ *//;s/ *$//')
+            echo -e "Your branch is behind ${YELLOW}$origin_name/$current_branch${ENDCOLOR} by ${BOLD}$behind_count${ENDCOLOR} commits"
+            echo -e "$behind_commits"
+        fi
+
+        if [ -n "$ahead_commits" ]; then
+            if [ -n "$behind_commits" ]; then
+                echo
+            fi
+            ahead_count=$(echo -e "$ahead_commits" | wc -l | sed 's/^ *//;s/ *$//')
+            echo -e "Your branch is ahead of ${YELLOW}$origin_name/$current_branch${ENDCOLOR} by ${BOLD}$ahead_count${ENDCOLOR} commits"
+            echo -e "$ahead_commits"
+        fi
+
+        echo
+        echo -e "${BLUE}Dry run only — no local refs were modified${ENDCOLOR}"
+        echo -e "Run ${YELLOW}gitb pull${ENDCOLOR} to apply changes"
+        exit
     fi
 
     if [ -n "$fetch" ]; then

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -17,6 +17,7 @@ function sync_script {
         push|p)         sync_push="true";;
         merge|m)        sync_merge="true";;
         mergep|mp|pm)   sync_merge="true"; sync_push="true";;
+        dry|d|dr)       sync_dry="true";;
         help|h)         help="true";;
         *)
             wrong_mode "sync" $1
@@ -25,7 +26,9 @@ function sync_script {
 
     ### Print header
     header_msg="GIT SYNC"
-    if [ -n "${sync_merge}" ]; then
+    if [ -n "${sync_dry}" ]; then
+        header_msg="$header_msg DRY RUN"
+    elif [ -n "${sync_merge}" ]; then
         if [ -n "${sync_push}" ]; then
             header_msg="$header_msg MERGE & PUSH"
         else
@@ -47,6 +50,7 @@ function sync_script {
         msg="$msg\n${BOLD}push${ENDCOLOR}_p_Fetch $main_branch, rebase current branch onto it, and force push"
         msg="$msg\n${BOLD}merge${ENDCOLOR}_m_Fetch $main_branch and merge it into current branch"
         msg="$msg\n${BOLD}mergep${ENDCOLOR}_mp|pm_Fetch $main_branch, merge it into current branch, and push"
+        msg="$msg\n${BOLD}dry${ENDCOLOR}_d|dr_Preview commits that sync would bring in from $main_branch without modifying local refs"
         msg="$msg\n${BOLD}help${ENDCOLOR}_h_Show this help"
         echo -e "$(echo -e "$msg" | column -ts'_')"
         exit
@@ -55,7 +59,70 @@ function sync_script {
 
     ### Check if already on default branch
     if [ "$current_branch" == "$main_branch" ]; then
-        echo -e "${YELLOW}Already on ${main_branch}, use ${BOLD}gitb pull${NORMAL}${YELLOW} instead${ENDCOLOR}"
+        if [ -n "$sync_dry" ]; then
+            echo -e "${YELLOW}Already on ${main_branch}, use ${BOLD}gitb pull dry${NORMAL}${YELLOW} instead${ENDCOLOR}"
+        else
+            echo -e "${YELLOW}Already on ${main_branch}, use ${BOLD}gitb pull${NORMAL}${YELLOW} instead${ENDCOLOR}"
+        fi
+        exit
+    fi
+
+
+    ### Dry-run mode: preview the sync without modifying any local state
+    if [ -n "$sync_dry" ]; then
+        if [ -z "$origin_name" ]; then
+            echo -e "${RED}No git remote configured.${ENDCOLOR}"
+            echo -e "Use ${BLUE}git remote add origin <url>${ENDCOLOR} to set it up first."
+            exit 1
+        fi
+
+        echo -e "${YELLOW}Checking ${origin_name}/${main_branch} for incoming commits...${ENDCOLOR}"
+        echo
+
+        ### Snapshot the remote-tracking ref so we can restore it after the fetch.
+        ### git fetch always honors the configured refs/heads/*:refs/remotes/origin/* refspec,
+        ### so we save the current value and roll it back once we've inspected FETCH_HEAD.
+        remote_tracking_ref="refs/remotes/$origin_name/$main_branch"
+        saved_ref=$(git rev-parse --verify --quiet "$remote_tracking_ref")
+
+        dry_output=$(git fetch --no-tags "$origin_name" "$main_branch" 2>&1)
+        dry_code=$?
+
+        if [ -n "$saved_ref" ]; then
+            git update-ref "$remote_tracking_ref" "$saved_ref" 2>/dev/null
+        else
+            git update-ref -d "$remote_tracking_ref" 2>/dev/null
+        fi
+
+        if [ $dry_code != 0 ]; then
+            echo -e "${RED}Cannot fetch ${main_branch}! Error message:${ENDCOLOR}"
+            echo -e "$dry_output"
+            exit $dry_code
+        fi
+
+        ### Commits on main that current branch doesn't have (would be applied by sync)
+        incoming=$(commit_list 999 "tab" "HEAD..FETCH_HEAD")
+        ### Commits on current branch not on main (would be replayed during rebase)
+        local_only=$(commit_list 999 "tab" "FETCH_HEAD..HEAD")
+
+        if [ -z "$incoming" ]; then
+            echo -e "${GREEN}Already up to date with ${main_branch}${ENDCOLOR}"
+        else
+            incoming_count=$(echo -e "$incoming" | wc -l | sed 's/^ *//;s/ *$//')
+            echo -e "${BOLD}$incoming_count${ENDCOLOR} commits on ${YELLOW}${origin_name}/${main_branch}${ENDCOLOR} would be applied to ${YELLOW}${current_branch}${ENDCOLOR}"
+            echo -e "$incoming"
+        fi
+
+        if [ -n "$local_only" ]; then
+            echo
+            local_count=$(echo -e "$local_only" | wc -l | sed 's/^ *//;s/ *$//')
+            echo -e "${BOLD}$local_count${ENDCOLOR} local commits on ${YELLOW}${current_branch}${ENDCOLOR} would be replayed on top after rebase"
+            echo -e "$local_only"
+        fi
+
+        echo
+        echo -e "${BLUE}Dry run only — no local refs were modified${ENDCOLOR}"
+        echo -e "Run ${YELLOW}gitb sync${ENDCOLOR} to apply changes"
         exit
     fi
 


### PR DESCRIPTION
## Summary

Adds a true dry-run mode to `gitb pull` and `gitb sync` so you can preview what's incoming from the remote without modifying any local refs.

- **`gitb pull dry`** (aliases `d`, `dr`) — shows commits you're ahead/behind on `origin/<current>`, while leaving the remote-tracking ref untouched.
- **`gitb sync dry`** (aliases `d`, `dr`) — shows commits on `origin/<main>` that `sync` would apply to your branch, plus the local commits that would be replayed on top during rebase.

Both modes contact the remote via `git fetch` (so the data is fresh) but snapshot `refs/remotes/<origin>/<branch>` before the fetch and restore it afterward — `git fetch` always applies the configured `refs/heads/*:refs/remotes/origin/*` refspec even when an explicit refspec is passed, so a manual restore is the only reliable way to keep the remote-tracking ref pinned. The diff is computed against `FETCH_HEAD`, which survives the restore.

The existing `pull fetch` mode is unchanged — it still fetches and advances the remote-tracking ref. `dry` is the new option for users who want to peek without any local state change.

## Test plan

- [x] `bash -n scripts/pull.sh scripts/sync.sh` — clean
- [x] `make test` — all 345 bats tests pass
- [x] Manual smoke test against a local bare-repo remote:
  - [x] `pull dry` with new remote commit: prints "behind by N", `origin/main` unchanged
  - [x] `pull dry` with no diff: prints "Already up to date", `origin/main` unchanged
  - [x] `pull dry` with only local commits ahead: prints "ahead by N", `origin/main` unchanged
  - [x] `sync dry` on a feature branch: prints incoming-from-main + local-to-replay, `origin/main` unchanged
- [x] Help output (`gitb pull h`, `gitb sync h`) lists the new mode
- [x] README tables (`gitb pull`, `gitb sync`, top-level command index) updated

https://claude.ai/code/session_01Q6gALCfLuDrzd3W4opVXau

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6gALCfLuDrzd3W4opVXau)_