### PR TITLE
feat(pull): show git's native progress bar during gitb pull

### DIFF
--- a/scripts/pull.sh
+++ b/scripts/pull.sh
@@ -176,7 +176,8 @@ function pull_script {
                 else
                     echo -e "${GREEN}✓ Fetched '$origin_name/$current_branch'${ENDCOLOR}"
                 fi
-                if [ "$fetch_output" != "" ]; then
+                ### Skip re-echo when progress (and the summary) was already streamed live
+                if [ "$fetch_output" != "" ] && [ -z "$fetch_progress_shown" ]; then
                     echo
                     echo -e "$fetch_output"
                 fi
@@ -234,13 +235,40 @@ function pull_script {
 # $3: is all
 # Returns:
 #      * fetch_code - if it is not zero - there is no such branch in origin
+#      * fetch_output - captured combined stdout/stderr
+#      * fetch_progress_shown - "true" when git's progress was streamed live to the terminal
 function fetch {
-    if [ -n "$3" ]; then
-        fetch_output=$(git fetch --all 2>&1)
-        fetch_code=$?
-    else
-        fetch_output=$(git fetch "$2" "$1" 2>&1)
-        fetch_code=$?
+    fetch_progress_shown=""
+
+    ### Stream git's native progress bar to the terminal when running interactively,
+    ### so the user gets feedback during long fetches. Output is still captured via
+    ### tee so error handling and downstream checks (e.g. "couldn't find remote ref")
+    ### keep working. Fall back to silent capture when there's no TTY (tests, CI).
+    if [ -t 1 ] && [ -t 2 ]; then
+        local tmp_file
+        tmp_file=$(mktemp 2>/dev/null)
+        if [ -n "$tmp_file" ]; then
+            if [ -n "$3" ]; then
+                git fetch --all --progress 2>&1 | tee "$tmp_file"
+                fetch_code=${PIPESTATUS[0]}
+            else
+                git fetch --progress "$2" "$1" 2>&1 | tee "$tmp_file"
+                fetch_code=${PIPESTATUS[0]}
+            fi
+            fetch_output=$(cat "$tmp_file")
+            rm -f "$tmp_file"
+            fetch_progress_shown="true"
+        fi
+    fi
+
+    if [ -z "$fetch_progress_shown" ]; then
+        if [ -n "$3" ]; then
+            fetch_output=$(git fetch --all 2>&1)
+            fetch_code=$?
+        else
+            fetch_output=$(git fetch "$2" "$1" 2>&1)
+            fetch_code=$?
+        fi
     fi
 
     if [ $fetch_code == 0 ] ; then
@@ -249,7 +277,10 @@ function fetch {
 
     if [[ ${fetch_output} != *"couldn't find remote ref"* ]]; then
         echo -e "${RED}✗ Cannot fetch '$1'.${ENDCOLOR}"
-        echo -e "${fetch_output}"
+        ### Avoid re-printing output that the user already saw streamed live
+        if [ -z "$fetch_progress_shown" ]; then
+            echo -e "${fetch_output}"
+        fi
         exit $fetch_code
     fi
 


### PR DESCRIPTION
## Summary

When running `gitb pull` (or `gitb pl`) on a large repository, the user previously saw only `Pulling 'origin/main'...` followed by a long, unexplained silence — git's built-in progress output (`remote: Counting objects... Receiving objects: 16% (36/217), 19.28 MiB | 1.17 MiB/s`) was being swallowed because the `fetch` helper captured all output via `$(...)` for error-handling purposes.

This PR makes that progress visible:

- `scripts/pull.sh` `fetch()` now `tee`s git's output to a temp file when running in a TTY, so progress streams to the terminal in real time while the captured copy is still available for error-handling logic (e.g. the existing `"couldn't find remote ref"` substring check).
- Passes `--progress` so git emits progress even though stderr is going through a pipe.
- Falls back to the original silent capture when there's no TTY (tests, CI, piped output).
- Skips the now-redundant re-echo of `$fetch_output` in fetch-only mode and in the error path when progress was already shown live, to avoid duplicating output the user just watched scroll by.

## Test plan

- [x] `bash -n scripts/pull.sh` — syntax check passes
- [ ] Run `gitb pull` against a fresh clone with many incoming objects and confirm git's `Receiving objects: X%` line updates live
- [ ] Run `gitb pull fetch` and confirm the post-fetch summary (`✓ Fetched origin/main`, behind-by-N commits) still renders correctly without duplicating the `From github.com:...` line
- [ ] Run `gitb pull` when already up to date — should still print `✓ Already up to date` with no extra noise
- [ ] Run `gitb pull` against a branch that doesn't exist remotely — should still print the friendly `Branch 'X' does not exist on origin.` message
- [ ] Run the test suite (`./tests/run_tests.sh`) in a non-TTY shell to confirm the fallback path keeps existing tests green

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhjZKYtx2MX4bWx67CN5i7)_