### PR TITLE
fix(gitb): escape $(curl) in bash<4 upgrade message so it prints literally

### DIFF
--- a/scripts/gitb.sh
+++ b/scripts/gitb.sh
@@ -47,7 +47,7 @@ if ((BASH_VERSINFO[0] < 4)); then
 
     printf "Sorry, you need at least bash-4.0 to run gitbasher.\n\n"
     printf "Linux (Debian/Ubuntu):\n    sudo apt update && sudo apt install --only-upgrade bash\n\n"
-    printf "macOS:\n    1) Install Homebrew (if missing):\n       /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"\n    2) Install newer bash:\n       brew install bash\n    3) Optional: make it your default shell (then restart Terminal):\n       sudo sh -c 'echo /opt/homebrew/bin/bash >> /etc/shells' && chsh -s /opt/homebrew/bin/bash\n\n"
+    printf "macOS:\n    1) Install Homebrew (if missing):\n       /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"\n    2) Install newer bash:\n       brew install bash\n    3) Optional: make it your default shell (then restart Terminal):\n       sudo sh -c 'echo /opt/homebrew/bin/bash >> /etc/shells' && chsh -s /opt/homebrew/bin/bash\n\n"
     printf "Or run gitb explicitly with the newer bash when installed:\n    /opt/homebrew/bin/bash $0 \"\$@\"\n\n"
     exit 1; 
 fi


### PR DESCRIPTION
## Summary

When a new user on macOS (still on Apple's default bash 3.2) runs `gitb` without Homebrew bash installed, the bash version check at `scripts/gitb.sh:48` falls through to a helpful upgrade message. That message was wrapped in **double quotes**, so this fragment:

```
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
```

was eagerly expanded by the shell — `printf` actually downloaded the Homebrew installer over the network and embedded the full body of `install.sh` into the error output. Users saw hundreds of lines of Homebrew bash code instead of a one-line install command.

Fix: escape the `$` so `printf` prints the literal `$(curl ...)` instruction the way users are meant to copy-paste it.

## Test plan

- [x] Reproduced the broken output by running the original `printf` line.
- [x] Verified the escaped version prints `/bin/bash -c "$(curl -fsSL ...)"` literally with no network call.
- [ ] Manual: on a macOS box with only `/bin/bash` 3.2, run `gitb` and confirm the message is short and copy-pasteable.

Reported by a new macOS user — see issue context: `gitb cfg ai` on a fresh install dumped the Homebrew installer source into the terminal.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QvFEG1p4PoXuaJCGNe52Ud)_