### PR TITLE
feat(clone): add gitb clone command

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -45,6 +45,7 @@ function print_help {
     echo
 
     printf "$hdr" "SETUP"
+    printf "$row" "$CMD" "clone (cl, clo)"        "Clone a remote repo and initialize gitbasher in it"
     printf "$row" "$CMD" "origin (or, o, remote)"  "Manage remotes"
     printf "$row" "$CMD" "hook (ho, hk)"           "Manage git hooks"
     printf "$row" "$CMD" "worktree (wt, tree)"     "Manage git worktrees"
@@ -155,6 +156,9 @@ case "$1" in
     ;;
     origin|or|o|remote)
         origin_script "$2" "$3"
+    ;;
+    clone|cl|clo)
+        clone_script "$2" "$3"
     ;;
     update|up|upd)
         update_script "$2"

--- a/scripts/clone.sh
+++ b/scripts/clone.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+### Script for cloning a remote repository
+# Clones with progress, cds into the new directory inside the script
+# process, and initializes gitbasher local config so the cloned repo is
+# ready to use. The user's shell cwd cannot be changed from a child
+# process, so the final message prints the `cd` command for the user.
+
+
+### Function to derive a default destination directory from a git URL
+# $1: validated git URL
+# Echoes: destination directory name
+function _gitb_clone_dest_from_url {
+    local url="$1"
+    # Strip optional trailing .git
+    local stripped="${url%.git}"
+    # Take the last path component, regardless of separator (':' for git@host:user/repo, '/' otherwise)
+    local last="${stripped##*/}"
+    last="${last##*:}"
+    echo "$last"
+}
+
+
+### Function to print the clone help block
+# $1: column width used by help table formatters
+function _gitb_print_clone_help {
+    local PAD=14
+    echo -e "usage: ${YELLOW}gitb clone <url> [destination]${ENDCOLOR}"
+    echo
+    echo -e "Clone a remote repository, show progress, and initialize gitbasher in it."
+    echo
+    print_help_header $PAD
+    print_help_row $PAD "<url>"         "" "Git URL to clone (https, ssh, or git@)"
+    print_help_row $PAD "[destination]" "" "Optional target directory (default: repo name)"
+    print_help_row $PAD "help"          "h" "Show this help"
+    echo
+    echo -e "${YELLOW}Examples${ENDCOLOR}"
+    echo -e "  ${GREEN}gitb clone https://github.com/user/repo.git${ENDCOLOR}"
+    echo -e "  ${GREEN}gitb clone git@github.com:user/repo.git my-repo${ENDCOLOR}"
+    exit
+}
+
+
+### Main function
+# $1: URL to clone (or "help")
+# $2: optional destination directory
+function clone_script {
+    echo -e "${YELLOW}GIT CLONE${ENDCOLOR}"
+    echo
+
+    case "$1" in
+        ""|help|h) _gitb_print_clone_help ;;
+    esac
+
+    local raw_url="$1"
+    local dest="$2"
+
+    if ! validate_git_url "$raw_url"; then
+        echo -e "${RED}✗ Invalid git URL format: $raw_url${ENDCOLOR}" >&2
+        echo -e "${YELLOW}Expected one of:${ENDCOLOR}" >&2
+        echo -e "  https://host/user/repo.git" >&2
+        echo -e "  git@host:user/repo.git" >&2
+        echo -e "  ssh://git@host/repo.git" >&2
+        exit 1
+    fi
+    local url="$validated_url"
+
+    if [ -z "$dest" ]; then
+        dest=$(_gitb_clone_dest_from_url "$url")
+    fi
+
+    if [ -z "$dest" ]; then
+        echo -e "${RED}✗ Could not determine target directory from URL.${ENDCOLOR}" >&2
+        echo -e "${YELLOW}Pass a destination explicitly: ${GREEN}gitb clone <url> <dir>${ENDCOLOR}" >&2
+        exit 1
+    fi
+
+    if ! sanitize_file_path "$dest"; then
+        echo -e "${RED}✗ Invalid destination path: $dest${ENDCOLOR}" >&2
+        exit 1
+    fi
+    dest="$sanitized_file_path"
+
+    if [ -e "$dest" ]; then
+        echo -e "${RED}✗ Destination '$dest' already exists.${ENDCOLOR}" >&2
+        echo -e "${YELLOW}Remove it first or pass a different destination.${ENDCOLOR}" >&2
+        exit 1
+    fi
+
+    echo -e "Source: ${BLUE}$url${ENDCOLOR}"
+    echo -e "Target: ${BLUE}$dest${ENDCOLOR}"
+    echo
+
+    # --progress forces a progress bar even when stderr is not a TTY (e.g. piped),
+    # matching what users expect from `gitb clone`.
+    if ! git clone --progress "$url" "$dest"; then
+        echo
+        echo -e "${RED}✗ Clone failed.${ENDCOLOR}" >&2
+        exit 1
+    fi
+
+    echo
+    echo -e "${GREEN}✓ Cloned into '$dest'${ENDCOLOR}"
+
+    local target_abs
+    target_abs=$(cd "$dest" 2>/dev/null && pwd)
+    if [ -z "$target_abs" ]; then
+        echo -e "${RED}✗ Failed to enter directory '$dest'.${ENDCOLOR}" >&2
+        exit 1
+    fi
+
+    if ! cd "$target_abs"; then
+        echo -e "${RED}✗ Failed to cd into '$target_abs'.${ENDCOLOR}" >&2
+        exit 1
+    fi
+
+    # Initialize gitbasher's per-repo config. Mirrors the local config writes
+    # in init.sh so the first interactive `gitb` invocation inside the clone
+    # treats it as a fresh repo and shows the welcome banner once.
+    local cloned_branch
+    cloned_branch=$(git branch --show-current 2>/dev/null)
+    if [ -z "$cloned_branch" ]; then
+        cloned_branch="main"
+    fi
+    git config --local gitbasher.branch "$cloned_branch" 2>/dev/null
+    git config --local gitbasher.scopes "" 2>/dev/null
+    git config --local gitbasher.isfirst "true" 2>/dev/null
+
+    echo -e "${GREEN}✓ Initialized gitbasher in '$dest'${ENDCOLOR}"
+    echo
+    echo -e "${CYAN}💡 Enter the new repo with:${ENDCOLOR}"
+    echo -e "  ${GREEN}cd $target_abs${ENDCOLOR}"
+}

--- a/scripts/gitb.sh
+++ b/scripts/gitb.sh
@@ -16,11 +16,23 @@ if [ "$1" == "init" ] || [ "$1" == "i" ]; then
     git init
 fi
 
+# `clone` is the only other command that runs from outside a git repo: it
+# creates the repo it then operates on. Skip the "not a git repository" guard
+# below so the clone handler can run; init.sh has its own guard for the same
+# situation.
+_gitb_outside_repo_ok=""
+case "$1" in
+    clone|cl|clo) _gitb_outside_repo_ok="true" ;;
+esac
+
 git_check=$(git branch --show-current 2>&1)
 if [[ "$git_check" == *"fatal: not a git repository"* ]]; then
-    echo "You can use gitb only in a git repository"
-    exit
+    if [ -z "$_gitb_outside_repo_ok" ]; then
+        echo "You can use gitb only in a git repository"
+        exit
+    fi
 fi
+unset _gitb_outside_repo_ok
 
 
 ### Cannot use bash version less than 4 because of many features that was added to language in that version
@@ -98,6 +110,7 @@ source scripts/gitlog.sh || { echo "gitbasher: failed to load scripts/gitlog.sh"
 source scripts/worktree.sh || { echo "gitbasher: failed to load scripts/worktree.sh" >&2; exit 1; }
 source scripts/hooks.sh || { echo "gitbasher: failed to load scripts/hooks.sh" >&2; exit 1; }
 source scripts/origin.sh || { echo "gitbasher: failed to load scripts/origin.sh" >&2; exit 1; }
+source scripts/clone.sh || { echo "gitbasher: failed to load scripts/clone.sh" >&2; exit 1; }
 source scripts/update.sh || { echo "gitbasher: failed to load scripts/update.sh" >&2; exit 1; }
 source scripts/uninstall.sh || { echo "gitbasher: failed to load scripts/uninstall.sh" >&2; exit 1; }
 source scripts/completion.sh || { echo "gitbasher: failed to load scripts/completion.sh" >&2; exit 1; }

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -21,9 +21,12 @@ NORMAL="\033[0m"
 # $2: default value
 # Returns: config value
 function get_config_value {
-    value=$(git config --local --get "$1")
+    # Silence stderr: `git config --local --get` prints "fatal: --local can
+    # only be used inside a git repository" when called outside a repo, which
+    # leaks during the `gitb clone` flow that runs from a non-repo cwd.
+    value=$(git config --local --get "$1" 2>/dev/null)
     if [ "$value" == "" ]; then
-        value=$(git config --global --get "$1")
+        value=$(git config --global --get "$1" 2>/dev/null)
         if [ "$value" == "" ]; then
             value=$2
         fi
@@ -110,10 +113,24 @@ function validate_git_url {
 # helper functions above without paying the ~150ms tax of probing git config
 # / remotes / branches. Not a user-facing knob; values other than empty are
 # treated as "skip", but no public guarantee is made about specific values.
+#
+# `gitb clone` also lands here from outside any git repo so that clone_script
+# can reuse helpers like validate_git_url, so additionally bail when there is
+# no enclosing repo to query. `return 0` only works because this file is
+# `source`d in tests; in the built `gitb` binary all sources are inlined so a
+# bare top-level `return` would fail — the per-repo block below is therefore
+# also wrapped in an explicit guard.
+_gitb_init_run_queries="true"
 if [ -n "$GITBASHER_SKIP_INIT_QUERIES" ]; then
+    _gitb_init_run_queries=""
     return 0
 fi
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    _gitb_init_run_queries=""
+fi
 
+
+if [ -n "$_gitb_init_run_queries" ]; then
 
 ### Branches
 current_branch=$(git branch --show-current)
@@ -132,7 +149,7 @@ fi
 
 ### Remote
 origin_name=$(git remote -v | head -n 1 | sed 's/\t.*//')
-if [ "$origin_name" == "" ]; then 
+if [ "$origin_name" == "" ]; then
     # Skip interactive prompt if in test mode or stdin is not a TTY (e.g., in tests or scripts)
     if [ -z "$GITBASHER_TEST_MODE" ] && [ -t 0 ]; then
         # Interactive mode: prompt user for remote setup
@@ -147,7 +164,7 @@ if [ "$origin_name" == "" ]; then
         fi
 
         echo
-        
+
         read_editable_input remote_url "Remote repo URL: "
 
         if [ "$remote_url" == "" ]; then
@@ -180,7 +197,7 @@ if [ "$origin_name" == "" ]; then
             echo -e "${YELLOW}⚠  Repository '$remote_url' appears to be empty.${ENDCOLOR}"
         fi
         echo
-        
+
         origin_name=$(git remote -v | head -n 1 | sed 's/\t.*//')
     else
         # Non-interactive mode: skip remote setup, leave origin_name empty
@@ -212,3 +229,6 @@ fi
 ### Is this is a first run of gitbasher in this project?
 is_first=$(get_config_value gitbasher.isfirst "true")
 git config --local gitbasher.isfirst "false"
+
+fi
+unset _gitb_init_run_queries

--- a/tests/test_smoke_loadable.bats
+++ b/tests/test_smoke_loadable.bats
@@ -61,6 +61,12 @@ teardown() {
     [ "$status" -eq 0 ]
 }
 
+@test "smoke: clone.sh: source + dispatch help" {
+    source "${GITBASHER_ROOT}/scripts/clone.sh"
+    run clone_script help
+    [ "$status" -eq 0 ]
+}
+
 @test "smoke: commit.sh: source + dispatch help" {
     source "${GITBASHER_ROOT}/scripts/commit.sh"
     run commit_script help


### PR DESCRIPTION
## Summary
- Adds `gitb clone <url> [destination]` that wraps `git clone --progress`, shows progress, derives a default destination from the URL (or accepts one), validates URL format, and refuses to overwrite an existing path.
- After cloning, the script `cd`s into the new directory (inside the script process) and seeds gitbasher's per-repo config (`gitbasher.branch`, `gitbasher.scopes`, `gitbasher.isfirst=true`) so the first `gitb` invocation in the new repo shows the welcome banner. Because a child process cannot change the caller's shell cwd, the final output prints the exact `cd <path>` line for the user.
- Lets `clone` run from outside a git repo (mirrors the existing escape hatch for `init`): `gitb.sh` skips the "not a git repository" guard for the clone aliases, `init.sh` skips its per-repo queries when `git rev-parse --is-inside-work-tree` says we are not in a worktree, and `get_config_value` silences `stderr` so `git config --local` no longer leaks `fatal: --local can only be used inside a git repository` while running outside a repo.

## Test plan
- [x] `make build` produces a working binary
- [x] `gitb clone help` prints usage cleanly from outside any git repo
- [x] `gitb clone "not a url"` rejects invalid input with the standard error block
- [x] `gitb clone <local-repo>` clones (with progress), derives destination, sets `gitbasher.{branch,scopes,isfirst}` in the clone, and prints the `cd <abs-path>` hint
- [x] `gitb clone <url> <dest>` honors an explicit destination
- [x] Re-running into an existing destination fails fast
- [x] First `gitb` invocation inside the cloned repo prints the first-run banner (proves `isfirst=true` was persisted)
- [x] `make test` regressions: only the pre-existing `worktree_script: list mode prints worktrees` test fails on main (unrelated to this change); all other suites pass, including the new `smoke: clone.sh: source + dispatch help` test

https://claude.ai/code/session_016kHgdpmsNRgtsprxSrfHzk

---
_Generated by [Claude Code](https://claude.ai/code/session_016kHgdpmsNRgtsprxSrfHzk)_