### PR TITLE
feat(gitb): allow running outside a git repository for global commands

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -7,6 +7,12 @@ function print_help {
     echo
     echo -e "usage: ${YELLOW}gitb <command> [mode]${ENDCOLOR}"
     echo
+    if [ "$GITBASHER_NO_REPO" = "true" ]; then
+        echo -e "${YELLOW}⚠  Not inside a git repository.${ENDCOLOR}"
+        echo -e "Only ${BOLD}config${NORMAL}, ${BOLD}update${NORMAL}, ${BOLD}uninstall${NORMAL}, and ${BOLD}init${NORMAL} are available here."
+        echo -e "Run ${GREEN}gitb init${ENDCOLOR} in this directory to start a new repo, or ${GREEN}cd${ENDCOLOR} into one."
+        echo
+    fi
 
     local CMD=26
     local hdr="${YELLOW}%s${ENDCOLOR}\n"
@@ -58,11 +64,18 @@ function print_help {
     exit
 }
 
-project_name="$(get_repo_name)"
-repo_url="$(get_repo)"
+if [ "$GITBASHER_NO_REPO" = "true" ]; then
+    # No repo to name. Use "global config" so success messages like
+    # "Set 'X' as the ticket prefix in 'global config'" still read naturally.
+    project_name="global config"
+    repo_url=""
+else
+    project_name="$(get_repo_name)"
+    repo_url="$(get_repo)"
+fi
 
 ### Print settings f this is first run
-if [[ $is_first == "true" ]]; then 
+if [[ $is_first == "true" ]]; then
     git config --local gitbasher.scopes ""
 
     echo -e "${GREEN}Thanks for using gitbasher in project '$project_name'${ENDCOLOR}"

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -7,6 +7,12 @@
 
 ### Function asks user to select default gitbasher branch
 function set_default_branch {
+    if [ "$GITBASHER_NO_REPO" = "true" ]; then
+        echo -e "${RED}✗ Cannot pick a default branch outside a git repository.${ENDCOLOR}" >&2
+        echo -e "Run this inside a repo, or set one directly with ${GREEN}git config --global gitbasher.branch <name>${ENDCOLOR}." >&2
+        exit 1
+    fi
+
     echo -e "${YELLOW}Fetching remote branches...${ENDCOLOR}"
     echo
 
@@ -27,6 +33,7 @@ function set_default_branch {
     echo -e "${GREEN}✓ Set '${branch_name}' as the default gitbasher branch in '${project_name}'${ENDCOLOR}"
     echo
 
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nSet '${branch_name}' globally" "true"
     main_branch=$(set_config_value gitbasher.branch $branch_name "true")
@@ -84,6 +91,7 @@ function set_sep {
     echo -e "${GREEN}✓ Set '${sep}' as the branch name separator in '${project_name}'${ENDCOLOR}"
     echo
 
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nSet '${sep}' globally" "true"
     sep=$(set_config_value gitbasher.sep "$new_sep" "true")
@@ -122,6 +130,7 @@ function set_editor {
     echo -e "${GREEN}✓ Using editor '$editor' (${which_output})${ENDCOLOR}"
     echo
 
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nSet '${editor}' globally" "true"
     editor=$(set_config_value core.editor "$choice" "true")
@@ -166,6 +175,7 @@ function set_ticket {
     echo -e "${GREEN}✓ Set '${ticket_name}' as the ticket prefix in '${project_name}'${ENDCOLOR}"
     echo
 
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nSet '${ticket_name}' globally" "true"
     ticket_name=$(set_config_value gitbasher.ticket $ticket_name "true")
@@ -284,6 +294,7 @@ function configure_ai_key {
     echo -e "${GREEN}✓ Configured AI API key for '${provider}' in '${project_name}':${ENDCOLOR} ${BLUE}$(mask_api_key "$ai_api_key")${ENDCOLOR}"
     echo
 
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     echo -e "${RED}⚠  Global API keys are stored in plaintext in ~/.gitconfig.${ENDCOLOR}"
     echo -e "${CYAN}💡 For better security, set ${BLUE}GITB_AI_API_KEY_${provider_upper}${CYAN} as an environment variable instead.${ENDCOLOR}"
@@ -358,9 +369,11 @@ function configure_ai_provider {
     esac
     echo
 
-    echo -e "Do you want to set this provider ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
-    yes_no_choice "\nSet AI provider globally" "true"
-    set_config_value gitbasher.ai-provider "$new_provider" "true"
+    if [ "$GITBASHER_NO_REPO" != "true" ]; then
+        echo -e "Do you want to set this provider ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
+        yes_no_choice "\nSet AI provider globally" "true"
+        set_config_value gitbasher.ai-provider "$new_provider" "true"
+    fi
 
     # If the new provider needs an API key but none is configured for it,
     # walk the user through setting one now — this is the surprise the user
@@ -455,6 +468,7 @@ function configure_ai_model {
     echo -e "${GREEN}✓ Set AI model to '$model_input' for '${project_name}'${ENDCOLOR}"
     echo
 
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nSet AI model globally" "true"
     set_config_value gitbasher.ai-model "$model_input" "true"
@@ -517,6 +531,7 @@ function configure_ai_proxy {
     echo -e "  ${BLUE}gitb commit aif${ENDCOLOR}   - Fast AI commit through proxy"
     echo
    
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nSet AI proxy globally" "true"
     set_ai_proxy "$ai_proxy_input"
@@ -573,6 +588,7 @@ function configure_ai_history {
     echo -e "${GREEN}✓ Set AI commit history limit to ${limit_input} for '${project_name}'${ENDCOLOR}"
     echo
 
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nSet AI commit history limit globally" "true"
     git config --global gitbasher.ai-commit-history-limit "$limit_input"
@@ -646,6 +662,7 @@ function configure_ai_diff {
     fi
 
     echo
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to apply ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nApply AI diff settings globally" "true"
     if [ -n "$lines_input" ]; then
@@ -694,6 +711,13 @@ function set_scopes {
     fi
     scopes_raw="$validated_scopes"
 
+    if [ "$GITBASHER_NO_REPO" = "true" ]; then
+        git config --global --replace-all gitbasher.scopes "$scopes_raw"
+        scopes="$scopes_raw"
+        echo -e "${GREEN}✓ Set '${scopes}' as the global scopes list${ENDCOLOR}"
+        return
+    fi
+
     git config --local --replace-all gitbasher.scopes "$scopes_raw"
 
     scopes="$scopes_raw"
@@ -701,6 +725,7 @@ function set_scopes {
     echo -e "${GREEN}✓ Set '${scopes}' as the scopes list in '${project_name}'${ENDCOLOR}"
     echo
 
+    [ "$GITBASHER_NO_REPO" = "true" ] && exit
     echo -e "Do you want to set it ${YELLOW}globally${ENDCOLOR} for all projects (y/n)?"
     yes_no_choice "\nSet '${scopes}' globally" "true"
 
@@ -851,13 +876,18 @@ function set_user {
 
     echo
 
+    local _user_scope="--local"
+    if [ "$GITBASHER_NO_REPO" = "true" ]; then
+        _user_scope="--global"
+    fi
+
     if [ "$user_name" != "" ]; then
         echo -e "${GREEN}✓ Set user name to '${user_name}'${ENDCOLOR}"
-        git config --local --replace-all user.name "$user_name"
+        git config "$_user_scope" --replace-all user.name "$user_name"
     fi
     if [ "$user_email" != "" ]; then
         echo -e "${GREEN}✓ Set user email to '${user_email}'${ENDCOLOR}"
-        git config --local --replace-all user.email "$user_email"
+        git config "$_user_scope" --replace-all user.email "$user_email"
     fi
 }
 

--- a/scripts/gitb.sh
+++ b/scripts/gitb.sh
@@ -16,10 +16,27 @@ if [ "$1" == "init" ] || [ "$1" == "i" ]; then
     git init
 fi
 
+### Some subcommands work without a git repository — they only touch the
+### user's global gitbasher config, the installed binary, or print help.
+### Allow gitb to run from anywhere in those cases instead of bailing out.
+GITBASHER_NO_REPO=""
 git_check=$(git branch --show-current 2>&1)
 if [[ "$git_check" == *"fatal: not a git repository"* ]]; then
-    echo "You can use gitb only in a git repository"
-    exit
+    case "${1:-}" in
+        ""|help|man|--help|-h|version|--version|-v|\
+        config|cf|cfg|conf|\
+        update|up|upd|\
+        uninstall|uns|uni|\
+        init|i)
+            GITBASHER_NO_REPO="true"
+            export GITBASHER_NO_REPO
+            ;;
+        *)
+            echo "You can use 'gitb $1' only in a git repository."
+            echo "Run 'gitb help' to see commands that work anywhere (config, update, uninstall)."
+            exit 1
+            ;;
+    esac
 fi
 
 
@@ -54,7 +71,11 @@ fi
 
 
 ### Detect a stale .git/index.lock from a previously interrupted git operation
-git_dir=$(git rev-parse --git-dir 2>/dev/null)
+if [ "$GITBASHER_NO_REPO" = "true" ]; then
+    git_dir=""
+else
+    git_dir=$(git rev-parse --git-dir 2>/dev/null)
+fi
 if [ -n "$git_dir" ] && [ -e "$git_dir/index.lock" ]; then
     printf "\033[33mDetected %s/index.lock from a possibly interrupted git operation.\033[0m\n" "$git_dir"
     printf "Another git process may be running. Remove the lock and continue?\n"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -21,7 +21,10 @@ NORMAL="\033[0m"
 # $2: default value
 # Returns: config value
 function get_config_value {
-    value=$(git config --local --get "$1")
+    # Outside a repo, --local prints "fatal: --local can only be used inside a
+    # git repository" to stderr; quiet it so non-repo help / config prints
+    # don't get spammed with errors.
+    value=$(git config --local --get "$1" 2>/dev/null)
     if [ "$value" == "" ]; then
         value=$(git config --global --get "$1")
         if [ "$value" == "" ]; then
@@ -37,8 +40,10 @@ function get_config_value {
 # $2: value
 # $3: global flag
 # Returns: value
+# When running outside a git repository (GITBASHER_NO_REPO=true) every write
+# is routed to --global, since --local would fail with no .git/config to write.
 function set_config_value {
-    if [ -z "$3" ]; then
+    if [ -z "$3" ] && [ "$GITBASHER_NO_REPO" != "true" ]; then
         git config --local "$1" "$2"
     else
         git config --global "$1" "$2"
@@ -51,6 +56,11 @@ function set_config_value {
 # $1: config name
 # Returns: value
 function unset_config_value {
+    if [ "$GITBASHER_NO_REPO" = "true" ]; then
+        git config --global --unset "$1" 2>/dev/null
+        return
+    fi
+
     git config --unset "$1"
 
     # Check if global config exists and ask user if they want to clear it too
@@ -116,23 +126,35 @@ fi
 
 
 ### Branches
-current_branch=$(git branch --show-current)
+# Outside a git repo we can't (and don't need to) discover the current/default
+# branch. The subcommands that are allowed in no-repo mode (config, update,
+# uninstall, help) never read these, so leave them empty/defaulted.
+if [ "$GITBASHER_NO_REPO" = "true" ]; then
+    current_branch=""
+    main_branch=$(get_config_value gitbasher.branch "main")
+else
+    current_branch=$(git branch --show-current)
 
-main_branch=$(get_config_value gitbasher.branch "main")
-if [[ "$( git branch | grep -E "^[[:space:]*]*main[[:space:]]*$" )" == "" ]] && [[ "$( git branch | grep -E "^[[:space:]*]*master[[:space:]]*$" )" != "" ]]; then
-    main_branch="master"
-elif [[ "$(git branch | cat)" == "" ]]; then
-    main_branch=$current_branch
-fi
+    main_branch=$(get_config_value gitbasher.branch "main")
+    if [[ "$( git branch | grep -E "^[[:space:]*]*main[[:space:]]*$" )" == "" ]] && [[ "$( git branch | grep -E "^[[:space:]*]*master[[:space:]]*$" )" != "" ]]; then
+        main_branch="master"
+    elif [[ "$(git branch | cat)" == "" ]]; then
+        main_branch=$current_branch
+    fi
 
-if [ "$(get_config_value gitbasher.branch "")" == "" ]; then
-    git config --local gitbasher.branch "$main_branch"
+    if [ "$(get_config_value gitbasher.branch "")" == "" ]; then
+        git config --local gitbasher.branch "$main_branch"
+    fi
 fi
 
 
 ### Remote
-origin_name=$(git remote -v | head -n 1 | sed 's/\t.*//')
-if [ "$origin_name" == "" ]; then 
+if [ "$GITBASHER_NO_REPO" = "true" ]; then
+    origin_name=""
+else
+    origin_name=$(git remote -v | head -n 1 | sed 's/\t.*//')
+fi
+if [ "$origin_name" == "" ] && [ "$GITBASHER_NO_REPO" != "true" ]; then
     # Skip interactive prompt if in test mode or stdin is not a TTY (e.g., in tests or scripts)
     if [ -z "$GITBASHER_TEST_MODE" ] && [ -t 0 ]; then
         # Interactive mode: prompt user for remote setup
@@ -210,5 +232,12 @@ fi
 
 
 ### Is this is a first run of gitbasher in this project?
-is_first=$(get_config_value gitbasher.isfirst "true")
-git config --local gitbasher.isfirst "false"
+# The first-run welcome only makes sense for an actual project — skip it in
+# no-repo mode so we don't try to write gitbasher.isfirst into a missing
+# .git/config.
+if [ "$GITBASHER_NO_REPO" = "true" ]; then
+    is_first="false"
+else
+    is_first=$(get_config_value gitbasher.isfirst "true")
+    git config --local gitbasher.isfirst "false"
+fi


### PR DESCRIPTION
## Summary

Until now, `gitb` aborted with _"You can use gitb only in a git repository"_ unless the current working directory was inside a git checkout. That made it impossible to set up global defaults, run `gitb update`, or `gitb uninstall` without first `cd`'ing into a tracked project.

This PR adds a no-repo mode so a curated set of commands work from anywhere.

### What works outside a repo

| Command | Behaviour |
| --- | --- |
| `gitb help` / `--help` / version | Prints help with a banner explaining the limitation. |
| `gitb config <…>` (cfg / cf / conf) | Reads global config and writes through to `--global` directly. The "Set globally?" follow-up is skipped because the first write already went global. |
| `gitb update` | Runs the self-update flow (it only talks to GitHub Releases + the installed binary). |
| `gitb uninstall` | Cleans `gitbasher.*` keys from `--global` config and removes the binary. |
| `gitb init` | `git init`'s the cwd and continues through the normal first-run welcome. |

Anything else that genuinely needs a working tree (`commit`, `push`, `branch`, `merge`, …) still fails fast — but with a clearer message that points to what does work.

### How it's done

A new `GITBASHER_NO_REPO=true` env flag is set in `scripts/gitb.sh` when `git branch --show-current` reports we're outside a repo *and* the requested subcommand is on the allow-list. The rest of the bundle reacts to that flag:

- **`scripts/init.sh`** — skips current/main branch detection and the interactive remote prompt; `get_config_value` silences the "--local outside a repo" stderr spam; `set_config_value` routes all writes to `--global` so `cfg` flows actually persist; the first-run `gitbasher.isfirst` write is skipped.
- **`scripts/base.sh`** — substitutes `project_name="global config"` so success messages like _"✓ Set 'X' as the ticket prefix in 'global config'"_ still read cleanly, and adds a banner to `print_help`.
- **`scripts/config.sh`** — short-circuits the "Set globally?" follow-up prompt (the value is already global), routes `set_user` / `set_scopes` to `--global`, and refuses `gitb cfg default` in no-repo mode since it needs `git fetch`.

### Behavioural diff (smoke)

```
$ cd /tmp && gitb cfg ticket
GIT CONFIG TICKET PREFIX
Enter a ticket prefix
…
✓ Set 'myticket' as the ticket prefix in 'global config'

$ git config --global --get gitbasher.ticket
myticket

$ cd /tmp && gitb commit
You can use 'gitb commit' only in a git repository.
Run 'gitb help' to see commands that work anywhere (config, update, uninstall).
```

## Test plan

- [x] `make build` produces a working `dist/gitb`
- [x] `gitb help`, `gitb cfg`, `gitb cfg ticket`, `gitb update help`, `gitb uninstall help`, `gitb init` all run from a non-repo directory
- [x] `gitb commit` / `push` / `branch` outside a repo print the new "only in a git repository" message and exit non-zero
- [x] `gitb init` from a non-repo directory `git init`'s the dir and then proceeds into the standard first-run welcome (inheriting the global ticket prefix as expected)
- [x] `make test` — smoke / config-setter / bundle-integration / build-script / common-utils / sanitization suites all pass. Other suites' failures in CI sandbox are pre-existing (`column: command not found`) and reproduce on the parent commit unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WNPHhRxuxRdAGo3rvsTjjT)_