### PR TITLE
feat(commit): cap atomic split at a configurable number of scopes

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -258,21 +258,41 @@ function detect_scopes_from_staged_files {
             # Combine: filenames first, then directories
             detected_scopes_sorted=("${filename_sorted[@]}" "${directory_sorted[@]}")
             
-            # Extract just the token names for the final result (limit to 9 scopes)
+            # Extract just the token names for the final result (limit to 9 scopes).
+            # Strip leading/trailing separators (.github -> github) and drop
+            # duplicates that collapse to the same clean name.
             final_scopes=()
             count=0
+            declare -A seen_norm=()
             for entry in "${detected_scopes_sorted[@]}"; do
                 if [ $count -ge 9 ]; then
                     break
                 fi
                 token="${entry##*:}"  # Extract token after last colon
+                token=$(normalize_scope_name "$token")
+                [ -z "$token" ] && continue
+                [ -n "${seen_norm[$token]:-}" ] && continue
+                seen_norm["$token"]=1
                 final_scopes+=("$token")
                 count=$((count + 1))
             done
-            
+
             detected_scopes="${final_scopes[*]}"
         fi
     fi
+}
+
+### Strip leading/trailing separators from a scope name so it reads cleanly
+### as `type(scope):` — e.g. ".superpowers" -> "superpowers", "_deploy" ->
+### "deploy", "build-" -> "build". Dotfile dirs and underscore-prefixed
+### filenames are common and shouldn't leak their punctuation into commit
+### scopes. Returns the trimmed name (may be empty if it was all separators).
+# $1: raw scope name
+function normalize_scope_name {
+    local s="$1"
+    while [[ "$s" == [._-]* ]]; do s="${s#?}"; done
+    while [[ "$s" == *[._-] ]]; do s="${s%?}"; done
+    printf '%s' "$s"
 }
 
 ### Function to map staged files to detected scopes (for atomic-split commits)
@@ -325,6 +345,10 @@ function build_split_groups_from_staged {
             comp_lower="${comp,,}"
             comp_no_ext_lower="${comp_lower%.*}"
             [ -z "$comp_no_ext_lower" ] && comp_no_ext_lower="$comp_lower"
+            # detected scopes are normalized (.github -> github), so normalize
+            # the component too before comparing.
+            comp_lower=$(normalize_scope_name "$comp_lower")
+            comp_no_ext_lower=$(normalize_scope_name "$comp_no_ext_lower")
             for scope in "${scopes_arr[@]}"; do
                 if [ "$comp_lower" = "$scope" ] || [ "$comp_no_ext_lower" = "$scope" ]; then
                     assigned="$scope"
@@ -343,6 +367,10 @@ function build_split_groups_from_staged {
             local stem="${comps[$last_idx_inner]}"
             stem="${stem%.*}"          # drop the extension
             stem="${stem,,}"           # lowercase
+            # Strip leading/trailing separators (_deploy-production ->
+            # deploy-production) so they don't leak into the scope and so the
+            # generic-name check below sees the clean stem.
+            stem=$(normalize_scope_name "$stem")
             # Skip stems that are generic across many languages and rarely
             # carry semantic meaning (the per-feature scope is the parent
             # dir, which we've already filtered for being too generic).
@@ -420,7 +448,8 @@ function consolidate_split_groups {
                 if [[ "$comp_lower" =~ ^(src|lib|libs|scripts|bin|node_modules|vendor|tmp|temp|cache|logs|log|services|apps|packages|modules|components|cmd|internal)$ ]]; then
                     continue
                 fi
-                bucket="${comp_lower#.}"   # .github -> github
+                bucket=$(normalize_scope_name "$comp_lower")   # .github -> github
+                [ -z "$bucket" ] && continue
                 break
             done
             [ -z "$bucket" ] && bucket="misc"

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -361,9 +361,125 @@ function build_split_groups_from_staged {
         fi
     done <<< "$staged_files"
 
+    # Keep the split between atomic and broad: a huge changeset (e.g. a dir
+    # full of one-off files, each producing its own stem scope) must not
+    # explode into dozens of micro-commits.
+    consolidate_split_groups "$(get_max_split_groups)"
+
     # A split is only meaningful with 2+ groups
     if [ ${#split_group_keys[@]} -lt 2 ]; then
         return 1
+    fi
+    return 0
+}
+
+### Resolve the maximum number of split groups (scopes) allowed in one run.
+# Configurable via gitbasher.commit-max-split-groups; defaults to 7. Clamped
+# to a sane range (2..20) so a typo can't disable or over-fragment splitting.
+function get_max_split_groups {
+    local v
+    v=$(get_config_value gitbasher.commit-max-split-groups "7")
+    case "$v" in
+        ''|*[!0-9]*) v=7 ;;
+    esac
+    [ "$v" -lt 2 ] && v=2
+    [ "$v" -gt 20 ] && v=20
+    printf '%s' "$v"
+}
+
+### Cap the number of split groups so a large changeset stays reviewable.
+# When the grouping exceeds the cap, collapse it in two stages:
+#   1. Re-bucket every file by its first meaningful (non-generic) path
+#      component, stripping a leading dot (.github -> github). This folds a
+#      sprawl of per-file stem scopes into a handful of location scopes.
+#   2. If still over the cap, keep the largest (cap-1) groups and fold the
+#      long tail into "misc".
+# Operates in place on the globals split_groups / split_group_keys.
+# $1: maximum number of groups to allow (>=2)
+function consolidate_split_groups {
+    local max="$1"
+    case "$max" in ''|*[!0-9]*) max=7 ;; esac
+    [ "$max" -lt 2 ] && max=2
+    [ ${#split_group_keys[@]} -le "$max" ] && return 0
+
+    # --- Stage 1: re-bucket by first non-generic path component ---
+    local -A rebucket=()
+    local -a rebucket_keys=()
+    local key file bucket comp_lower i last_idx
+    local -a comps
+    for key in "${split_group_keys[@]}"; do
+        while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            IFS='/' read -r -a comps <<< "$file"
+            last_idx=$((${#comps[@]} - 1))
+            bucket=""
+            for i in "${!comps[@]}"; do
+                [ "$i" -eq "$last_idx" ] && continue   # skip the filename
+                comp_lower="${comps[$i],,}"
+                [ -z "$comp_lower" ] && continue
+                if [[ "$comp_lower" =~ ^(src|lib|libs|scripts|bin|node_modules|vendor|tmp|temp|cache|logs|log|services|apps|packages|modules|components|cmd|internal)$ ]]; then
+                    continue
+                fi
+                bucket="${comp_lower#.}"   # .github -> github
+                break
+            done
+            [ -z "$bucket" ] && bucket="misc"
+            if [ -z "${rebucket[$bucket]:-}" ]; then
+                rebucket_keys+=("$bucket")
+                rebucket[$bucket]="$file"
+            else
+                rebucket[$bucket]+=$'\n'"$file"
+            fi
+        done <<< "${split_groups[$key]}"
+    done
+
+    unset split_groups split_group_keys
+    declare -gA split_groups=()
+    split_group_keys=()
+    for key in "${rebucket_keys[@]}"; do
+        split_groups[$key]="${rebucket[$key]}"
+        split_group_keys+=("$key")
+    done
+
+    [ ${#split_group_keys[@]} -le "$max" ] && return 0
+
+    # --- Stage 2: keep the largest (max-1) groups, fold the rest into misc ---
+    local -a sized=()
+    local n
+    for key in "${split_group_keys[@]}"; do
+        n=$(printf '%s\n' "${split_groups[$key]}" | grep -c .)
+        sized+=("${n}"$'\t'"${key}")
+    done
+    IFS=$'\n' sized=($(printf '%s\n' "${sized[@]}" | sort -t$'\t' -k1,1nr -k2,2))
+    unset IFS
+
+    local -A kept=()
+    local -a kept_keys=()
+    local keep_limit=$((max - 1))
+    local misc_files="" idx=0 entry
+    for entry in "${sized[@]}"; do
+        key="${entry#*$'\t'}"
+        if [ "$idx" -lt "$keep_limit" ] && [ "$key" != "misc" ]; then
+            kept_keys+=("$key")
+            kept[$key]="${split_groups[$key]}"
+            idx=$((idx + 1))
+        elif [ -z "$misc_files" ]; then
+            misc_files="${split_groups[$key]}"
+        else
+            misc_files+=$'\n'"${split_groups[$key]}"
+        fi
+    done
+
+    unset split_groups split_group_keys
+    declare -gA split_groups=()
+    split_group_keys=()
+    for key in "${kept_keys[@]}"; do
+        split_groups[$key]="${kept[$key]}"
+        split_group_keys+=("$key")
+    done
+    if [ -n "$misc_files" ]; then
+        split_group_keys+=("misc")
+        split_groups[misc]="$misc_files"
     fi
     return 0
 }
@@ -422,13 +538,16 @@ function refine_groups_with_ai {
         heuristic_hint="$detected_scopes"
     fi
 
-    local system_prompt='You group staged git files into logical scopes for atomic commits.
+    local max_groups
+    max_groups=$(get_max_split_groups)
+
+    local system_prompt="You group staged git files into logical scopes for atomic commits.
 
 Input arrives in XML tags: a list of staged files, a diff summary, recent commit messages (for codebase scope conventions), and heuristic-detected candidate scope tokens.
 
-Task: assign EVERY staged file to a single scope. Use 2-5 groups when there is meaningful separation; use exactly 1 group only if all files truly belong together. Use lowercase scope names that match the style of <recent_commits>. Prefer scope names from <heuristic_candidates> when they fit the file path or change; invent new ones only when none of the candidates apply. Use "misc" for files with no clear scope (e.g., README, top-level config).
+Task: assign EVERY staged file to a single scope. Use 2 to ${max_groups} groups when there is meaningful separation; use exactly 1 group only if all files truly belong together. Never exceed ${max_groups} groups — when many files share a theme, prefer a single broader scope over several tiny ones. Use lowercase scope names that match the style of <recent_commits>. Prefer scope names from <heuristic_candidates> when they fit the file path or change; invent new ones only when none of the candidates apply. Use \"misc\" for files with no clear scope (e.g., README, top-level config).
 
-Output format: TSV only. One line per staged file in the form <scope><TAB><file_path>. No header, no prose, no markdown fences, no surrounding quotes. Every file from <staged_files> MUST appear exactly once. The file paths must be byte-identical to those in <staged_files>.'
+Output format: TSV only. One line per staged file in the form <scope><TAB><file_path>. No header, no prose, no markdown fences, no surrounding quotes. Every file from <staged_files> MUST appear exactly once. The file paths must be byte-identical to those in <staged_files>."
 
     local user_prompt="<recent_commits>
 ${recent_commits}
@@ -1030,6 +1149,9 @@ function perform_commit_split {
 # spanning multiple subdirs), AI refinement is invoked to propose a better
 # scope→file mapping. Disable with gitbasher.commit-ai-grouping = "never";
 # force always-on with "always".
+# The number of groups is capped at gitbasher.commit-max-split-groups (default
+# 7) so a huge changeset stays a handful of reviewable commits instead of
+# dozens of micro-commits — see consolidate_split_groups.
 # Returns to the caller (no exit) when the user declines or the split isn't
 # applicable; perform_commit_split exits the script directly on success.
 # $1: "true" to force the split flow even when the config says "ask"/"never"
@@ -1076,6 +1198,9 @@ function try_offer_commit_split {
             # AI failed; keep heuristic groups (may be empty)
             echo -e "${YELLOW}AI grouping failed, falling back to heuristic.${ENDCOLOR}"
         fi
+        # Safety net: cap AI's grouping too (the heuristic path is already
+        # capped inside build_split_groups_from_staged).
+        consolidate_split_groups "$(get_max_split_groups)"
     fi
 
     # After refinement we may finally have ≥2 groups even if heuristic returned 1

--- a/tests/test_commit_split_monorepo.bats
+++ b/tests/test_commit_split_monorepo.bats
@@ -21,6 +21,7 @@ load setup_suite
 
 setup() {
     setup_test_repo
+    GITBASHER_SKIP_INIT_QUERIES=1 source "${GITBASHER_ROOT}/scripts/init.sh"
     source "${GITBASHER_ROOT}/scripts/common.sh"
     source "${GITBASHER_ROOT}/scripts/commit.sh"
     cd "$TEST_REPO"
@@ -247,4 +248,106 @@ stage() {
         echo "services should not exist as a scope" >&2
         return 1
     fi
+}
+
+# --- Group-count cap (atomic vs broad balance) -----------------------------
+#
+# A huge changeset must not explode into dozens of micro-commits. When the
+# grouping exceeds the configured cap (gitbasher.commit-max-split-groups,
+# default 7), consolidate_split_groups collapses it: first by re-bucketing
+# files under their top-level directory, then by folding the long tail into
+# misc.
+
+@test "cap: build never produces more groups than the configured max" {
+    # 10 distinct top-level dirs would naively yield ~10 scopes.
+    for d in alpha bravo charlie delta echo foxtrot golf hotel india juliet; do
+        stage "$d/file.txt"
+    done
+
+    build_split_groups_from_staged
+    [ "${#split_group_keys[@]}" -le 7 ]
+}
+
+@test "cap: gitbasher.commit-max-split-groups is honored" {
+    git config --local gitbasher.commit-max-split-groups 3
+    for d in alpha bravo charlie delta echo foxtrot; do
+        stage "$d/file.txt"
+    done
+
+    build_split_groups_from_staged
+    [ "${#split_group_keys[@]}" -le 3 ]
+}
+
+@test "cap: get_max_split_groups defaults to 7 and clamps bad values" {
+    [ "$(get_max_split_groups)" -eq 7 ]
+
+    git config --local gitbasher.commit-max-split-groups 4
+    [ "$(get_max_split_groups)" -eq 4 ]
+
+    git config --local gitbasher.commit-max-split-groups notanumber
+    [ "$(get_max_split_groups)" -eq 7 ]
+
+    git config --local gitbasher.commit-max-split-groups 1
+    [ "$(get_max_split_groups)" -eq 2 ]
+
+    git config --local gitbasher.commit-max-split-groups 999
+    [ "$(get_max_split_groups)" -eq 20 ]
+}
+
+@test "consolidate: stem-fallback explosion collapses by top-level dir" {
+    declare -gA split_groups=()
+    split_group_keys=()
+    # Simulate the real repro: 6 workflow files + 6 node UI files, each
+    # currently sitting in its own filename-stem scope.
+    local i
+    for i in 1 2 3 4 5 6; do
+        split_groups[wf$i]=".github/workflows/job$i.yml"
+        split_group_keys+=("wf$i")
+    done
+    for i in 1 2 3 4 5 6; do
+        split_groups[ui$i]="node/apps/user-web/src/comp$i.tsx"
+        split_group_keys+=("ui$i")
+    done
+
+    consolidate_split_groups 7
+    # 12 stem scopes collapse to 2 location scopes (leading dot stripped).
+    [ "${#split_group_keys[@]}" -eq 2 ]
+    [ -n "${split_groups[github]:-}" ]
+    [ -n "${split_groups[node]:-}" ]
+    [ "$(printf '%s\n' "${split_groups[github]}" | grep -c .)" -eq 6 ]
+    [ "$(printf '%s\n' "${split_groups[node]}" | grep -c .)" -eq 6 ]
+}
+
+@test "consolidate: stage-2 keeps largest groups and folds tail into misc" {
+    declare -gA split_groups=()
+    split_group_keys=()
+    # 'a' is the biggest dir; b..i have a single file each.
+    split_groups[a]=$'a/1\na/2\na/3\na/4'
+    split_group_keys+=("a")
+    local d
+    for d in b c dd ee ff gg hh ii; do
+        split_groups[$d]="$d/1"
+        split_group_keys+=("$d")
+    done
+
+    consolidate_split_groups 4
+    [ "${#split_group_keys[@]}" -le 4 ]
+    # Largest group survives intact; the long tail is bundled into misc.
+    [ -n "${split_groups[a]:-}" ]
+    [ "$(printf '%s\n' "${split_groups[a]}" | grep -c .)" -eq 4 ]
+    [ -n "${split_groups[misc]:-}" ]
+}
+
+@test "consolidate: no-op when group count is within the cap" {
+    declare -gA split_groups=()
+    split_group_keys=()
+    split_groups[bff]="services/bff/main.go"
+    split_group_keys+=("bff")
+    split_groups[api]="services/api/main.go"
+    split_group_keys+=("api")
+
+    consolidate_split_groups 7
+    [ "${#split_group_keys[@]}" -eq 2 ]
+    [ -n "${split_groups[bff]:-}" ]
+    [ -n "${split_groups[api]:-}" ]
 }

--- a/tests/test_commit_split_monorepo.bats
+++ b/tests/test_commit_split_monorepo.bats
@@ -338,6 +338,45 @@ stage() {
     [ -n "${split_groups[misc]:-}" ]
 }
 
+# --- Scope-name normalization (no leading/trailing . _ - in scopes) --------
+
+@test "normalize: helper strips leading and trailing separators" {
+    [ "$(normalize_scope_name '.superpowers')" = "superpowers" ]
+    [ "$(normalize_scope_name '_deploy-production')" = "deploy-production" ]
+    [ "$(normalize_scope_name '.github')" = "github" ]
+    [ "$(normalize_scope_name 'build-')" = "build" ]
+    [ "$(normalize_scope_name '__init__')" = "init" ]
+    [ "$(normalize_scope_name 'bff')" = "bff" ]
+    # all-separator name collapses to empty
+    [ -z "$(normalize_scope_name '._-')" ]
+}
+
+@test "normalize: dotfile directory scope drops the leading dot" {
+    stage ".superpowers/config.yml"
+    stage ".superpowers/rules.md"
+    stage "src/app.ts"   # second scope so the split is meaningful
+
+    detect_scopes_from_staged_files
+    [[ "$detected_scopes" == *"superpowers"* ]]
+    [[ "$detected_scopes" != *".superpowers"* ]]
+
+    build_split_groups_from_staged
+    [ -n "${split_groups[superpowers]:-}" ]
+    [ -z "${split_groups[.superpowers]:-}" ]
+}
+
+@test "normalize: underscore-prefixed filename stem drops the underscore" {
+    stage "scripts/_deploy-production.sh"
+    stage "scripts/_build-services.sh"
+    stage "tests/test_a.py"   # second scope
+
+    build_split_groups_from_staged
+    [ -n "${split_groups[deploy-production]:-}" ]
+    [ -n "${split_groups[build-services]:-}" ]
+    [ -z "${split_groups[_deploy-production]:-}" ]
+    [ -z "${split_groups[_build-services]:-}" ]
+}
+
 @test "consolidate: no-op when group count is within the cap" {
     declare -gA split_groups=()
     split_group_keys=()


### PR DESCRIPTION
## Summary

The atomic-split feature could explode a large changeset into dozens of micro-commits — e.g. a `.github/workflows/` directory full of one-off files, each producing its own filename-stem scope (the reported `Split commit 2/114` case). This adds a balance between atomic and broad: a hard cap on the number of split groups per run.

- **New config `gitbasher.commit-max-split-groups`** (default **7**, clamped 2–20) — resolved by the new `get_max_split_groups` helper.
- **New `consolidate_split_groups`** runs after grouping and collapses excess scopes in two stages:
  1. Re-bucket every file by its first meaningful (non-generic) path component, stripping a leading dot (`.github` → `github`). This folds a sprawl of per-file stem scopes into a handful of location scopes.
  2. If still over the cap, keep the largest `(cap-1)` groups and fold the long tail into `misc`.
- Wired into both the heuristic path (`build_split_groups_from_staged`) and, as a safety net, after AI refinement in `try_offer_commit_split`.
- The **AI grouping prompt** now references the same cap (`Use 2 to N groups ... never exceed N`).

So a 114-file change no longer yields 114 commits — it stays a small, reviewable set of per-area commits.

## Test plan

- [x] Added 6 tests to `tests/test_commit_split_monorepo.bats` covering: build never exceeds the cap, config is honored, `get_max_split_groups` defaulting/clamping, stem-explosion collapse by top-level dir, stage-2 largest-kept + misc-tail, and no-op within cap.
- [x] All 19 tests in that file pass (`bats tests/test_commit_split_monorepo.bats`).
- [x] `test_commit_prompt.bats` (11 tests) still pass — no regressions.
- [x] `bash -n` clean on `scripts/commit.sh`; `make build` produces a syntactically valid bundle.

Note: `test_base_commands.bats` failures in this environment are pre-existing and unrelated (they require a built `dist/gitb`, which isn't generated here).


---
_Generated by [Claude Code](https://claude.ai/code/session_015tjvxSQ1vtDy8AZpUPANo6)_