### PR TITLE
feat(push): retry transient network failures with exponential backoff

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -598,6 +598,19 @@ function wrong_mode {
 }
 
 
+### Detect transient network/connectivity failures in git output that are worth
+### retrying (VPN flapping, DNS hiccups, SSH timeouts, dropped connections).
+### Authentication, permission and "[rejected]" errors are NOT network errors and
+### must never be retried here.
+# $1: combined stdout+stderr of a failed git network command
+# Returns: 0 (true) if the output looks like a transient network failure
+function is_network_error {
+    local output="$1"
+    echo "$output" | grep -qiE \
+        "Could not read from remote repository|Could not resolve host|Connection timed out|Operation timed out|connect to host|Connection refused|Connection reset|Network is unreachable|kex_exchange_identification|remote end hung up unexpectedly|unable to access|Failed to connect|early EOF|RPC failed|timed out|ssh: connect|Temporary failure in name resolution|[Bb]roken pipe|[Rr]ecv failure|[Ss]end failure|TLS connection|SSL connection|no route to host"
+}
+
+
 ### Function echoes (true return) url to current user's repo (remote)
 # Return: url to repo
 function get_repo {

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -19,78 +19,107 @@
 #     * push_output
 #     * push_code
 function push {
-    push_output=$(git push "$@" "${origin_name}" "${current_branch}" 2>&1)
-    push_code=$?
+    # Transient connectivity failures (VPN flapping, DNS hiccups, SSH timeouts)
+    # are retried with exponential backoff (2s, 4s, 8s, 16s) so a brief network
+    # blip no longer forces the user to ctrl+c and re-run the whole command —
+    # e.g. enabling a VPN mid-failure now recovers on the next attempt.
+    local push_max_retries=4
+    local push_retry_delay=2
+    local push_attempt=0
 
-    if [ $push_code -eq 0 ] ; then
-        echo -e "${GREEN}✓ Pushed to ${origin_name}/${current_branch}${ENDCOLOR}"
+    while true; do
+        push_output=$(git push "$@" "${origin_name}" "${current_branch}" 2>&1)
+        push_code=$?
 
-        repo=$(get_repo)
-        host=$(get_repo_host "$repo")
-        head_hash=$(git rev-parse HEAD 2>/dev/null)
+        if [ $push_code -eq 0 ] ; then
+            echo -e "${GREEN}✓ Pushed to ${origin_name}/${current_branch}${ENDCOLOR}"
 
-        print_link "Repo" "$repo"
+            repo=$(get_repo)
+            host=$(get_repo_host "$repo")
+            head_hash=$(git rev-parse HEAD 2>/dev/null)
 
-        # Direct link to the just-pushed commit
-        if [ -n "$head_hash" ]; then
-            commit_url=$(get_commit_url "$head_hash" "$repo")
-            if [ -n "$commit_url" ]; then
-                print_link "Commit" "$commit_url"
-            fi
-        fi
+            print_link "Repo" "$repo"
 
-        if [[ ${current_branch} != ${main_branch} ]]; then
-            branch_url=$(get_branch_url "${current_branch}" "$repo")
-            if [ -n "$branch_url" ]; then
-                print_link "Branch" "$branch_url"
-            fi
-
-            # Some hosts include a PR/MR link in the push output (first push, etc.)
-            link=$(echo "$push_output" | grep -Eo "https?://[^[:space:]]+" | head -n 1 | sed 's|^remote:[[:space:]]*||')
-
-            if [ "$host" = "github" ]; then
-                if [ -n "$link" ]; then
-                    print_link "New PR" "$link"
-                else
-                    new_pr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
-                    print_link "New PR" "$new_pr_url"
+            # Direct link to the just-pushed commit
+            if [ -n "$head_hash" ]; then
+                commit_url=$(get_commit_url "$head_hash" "$repo")
+                if [ -n "$commit_url" ]; then
+                    print_link "Commit" "$commit_url"
                 fi
-            elif [ "$host" = "gitlab" ]; then
-                if [ -n "$link" ]; then
-                    is_new=$(echo "$push_output" | grep -i "create a merge request")
-                    if [ -n "$is_new" ]; then
-                        print_link "New MR" "$link"
+            fi
+
+            if [[ ${current_branch} != ${main_branch} ]]; then
+                branch_url=$(get_branch_url "${current_branch}" "$repo")
+                if [ -n "$branch_url" ]; then
+                    print_link "Branch" "$branch_url"
+                fi
+
+                # Some hosts include a PR/MR link in the push output (first push, etc.)
+                link=$(echo "$push_output" | grep -Eo "https?://[^[:space:]]+" | head -n 1 | sed 's|^remote:[[:space:]]*||')
+
+                if [ "$host" = "github" ]; then
+                    if [ -n "$link" ]; then
+                        print_link "New PR" "$link"
                     else
-                        print_link "MR" "$link"
+                        new_pr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
+                        print_link "New PR" "$new_pr_url"
                     fi
-                else
-                    new_mr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
-                    print_link "New MR" "$new_mr_url"
-                fi
-            elif [ "$host" = "bitbucket" ]; then
-                if [ -n "$link" ]; then
-                    print_link "New PR" "$link"
-                else
-                    new_pr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
-                    print_link "New PR" "$new_pr_url"
+                elif [ "$host" = "gitlab" ]; then
+                    if [ -n "$link" ]; then
+                        is_new=$(echo "$push_output" | grep -i "create a merge request")
+                        if [ -n "$is_new" ]; then
+                            print_link "New MR" "$link"
+                        else
+                            print_link "MR" "$link"
+                        fi
+                    else
+                        new_mr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
+                        print_link "New MR" "$new_mr_url"
+                    fi
+                elif [ "$host" = "bitbucket" ]; then
+                    if [ -n "$link" ]; then
+                        print_link "New PR" "$link"
+                    else
+                        new_pr_url=$(get_new_pr_url "${main_branch}" "${current_branch}" "$repo")
+                        print_link "New PR" "$new_pr_url"
+                    fi
                 fi
             fi
+
+            # Link to CI runs for this branch
+            ci_url=$(get_ci_url "${current_branch}" "$repo")
+            if [ -n "$ci_url" ]; then
+                print_link "$(get_ci_label "$repo")" "$ci_url"
+            fi
+
+            exit
         fi
 
-        # Link to CI runs for this branch
-        ci_url=$(get_ci_url "${current_branch}" "$repo")
-        if [ -n "$ci_url" ]; then
-            print_link "$(get_ci_label "$repo")" "$ci_url"
+        ### Unpulled remote changes — caller pulls then retries; not a network issue.
+        if [[ $push_output == *"[rejected]"* ]]; then
+            return
         fi
 
-        exit
-    fi
+        ### Retry transient network failures with exponential backoff.
+        if is_network_error "$push_output" && [ $push_attempt -lt $push_max_retries ]; then
+            push_attempt=$((push_attempt + 1))
+            echo -e "${YELLOW}⚠  Network error while pushing — retrying in ${push_retry_delay}s (attempt ${push_attempt}/${push_max_retries})...${ENDCOLOR}"
+            echo "$push_output" | head -n 2
+            echo
+            sleep $push_retry_delay
+            push_retry_delay=$((push_retry_delay * 2))
+            continue
+        fi
 
-    if [[ $push_output != *"[rejected]"* ]]; then
+        ### Non-retryable error, or retries exhausted.
         echo -e "${RED}✗ Cannot push.${ENDCOLOR}"
         echo "$push_output"
+        if [ $push_attempt -gt 0 ]; then
+            echo
+            echo -e "${YELLOW}⚠  Still failing after ${push_attempt} retries — check your network/VPN, then run ${GREEN}gitb push${YELLOW} again.${ENDCOLOR}"
+        fi
         exit $push_code
-    fi
+    done
 }
 
 

--- a/tests/test_common_utils.bats
+++ b/tests/test_common_utils.bats
@@ -192,3 +192,45 @@ teardown() {
 
     [ -n "$to_exit" ]
 }
+
+# ===== is_network_error tests =====
+
+@test "is_network_error: detects SSH connect timeout" {
+    run is_network_error "ssh: connect to host gitlab.example.net port 22: Operation timed out"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_network_error: detects could not read from remote" {
+    run is_network_error "fatal: Could not read from remote repository."
+    [ "$status" -eq 0 ]
+}
+
+@test "is_network_error: detects could not resolve host" {
+    run is_network_error "ssh: Could not resolve hostname github.com: Name or service not known"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_network_error: detects connection refused" {
+    run is_network_error "fatal: unable to access 'https://...': Failed to connect to host: Connection refused"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_network_error: detects kex_exchange_identification" {
+    run is_network_error "kex_exchange_identification: Connection closed by remote host"
+    [ "$status" -eq 0 ]
+}
+
+@test "is_network_error: does NOT match rejected (unpulled changes)" {
+    run is_network_error "! [rejected]        main -> main (fetch first)"
+    [ "$status" -ne 0 ]
+}
+
+@test "is_network_error: does NOT match permission denied" {
+    run is_network_error "remote: Permission to user/repo.git denied to someone."
+    [ "$status" -ne 0 ]
+}
+
+@test "is_network_error: does NOT match generic push failure" {
+    run is_network_error "error: failed to push some refs to 'origin'"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Problem

When a push fails due to a transient connectivity issue — an SSH connect timeout, a DNS hiccup, a dropped VPN, or `fatal: Could not read from remote repository.` — gitbasher bailed out immediately with `✗ Cannot push.`. If you enabled your VPN *during* the failure (as happens in the screenshot below), the only recovery was to `ctrl+c` and re-run the whole command.

```
GIT PUSH FAST
...
✗ Cannot push.
ssh: connect to host gitlab.gibdev.net port 22: Operation timed out
fatal: Could not read from remote repository.
```

## Change

`push()` now retries transient network failures **up to 4 times with exponential backoff (2s, 4s, 8s, 16s)** before giving up. So a brief network blip — or enabling a VPN mid-failure — recovers on the next attempt automatically.

- **`is_network_error` helper** (in `common.sh`): matches transient connectivity errors (SSH timeouts, `Could not read from remote repository`, `Could not resolve host`, `Connection refused/reset`, `kex_exchange_identification`, `Failed to connect`, `RPC failed`, etc.) while **deliberately ignoring** `[rejected]` (unpulled changes — handled by the existing pull flow), permission denials, and generic push failures, which must never be silently retried.
- **Retry loop** around the `git push` call in `push()`, with a clear per-attempt message and a final hint to check the network/VPN if all retries are exhausted.
- **Unit tests** covering both the should-retry and must-not-retry classifications.

## Testing

`bats tests/test_common_utils.bats` — all 8 new `is_network_error` tests pass. (The 3 unrelated `list_branches` failures are pre-existing in this sandbox, which lacks the `column` command — not introduced by this change.)

https://claude.ai/code/session_014p1SbeJS4DCekGs1TMWjmA

---
_Generated by [Claude Code](https://claude.ai/code/session_014p1SbeJS4DCekGs1TMWjmA)_