### PR TITLE
Make gitbasher run on bash 3.2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@ Thanks for contributing! A few quick notes:
 
 - [ ] Works on macOS (BSD userland)
 - [ ] Works on Linux (GNU userland)
-- [ ] Bash 4+ syntax used; no Bash 3 path was broken
+- [ ] Bash 3.2 compatible — no `declare -A`, `mapfile`, `${var,,}`/`${var^^}`, or `read -i` (use the `gmap_*`/`to_lower`/`to_upper` helpers)
 
 ## Checklist
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,3 +130,50 @@ jobs:
 
       - name: Smoke Test
         run: ./dist/gitb
+
+  bash32:
+    # The real bash 3.2 gate. macOS ships /bin/bash 3.2.57 (the oldest bash we
+    # support), so run the whole suite under it — WITHOUT prepending Homebrew's
+    # bash to PATH — to prove gitbasher works without any bash 4+ feature.
+    needs: shellcheck
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify we are on system bash 3.2
+        run: |
+          /bin/bash --version | head -1
+          /bin/bash -c 'major=${BASH_VERSINFO[0]}; minor=${BASH_VERSINFO[1]}; \
+            echo "system bash: $major.$minor"; \
+            if [ "$major" -ne 3 ] || [ "$minor" -ne 2 ]; then \
+              echo "Expected /bin/bash to be 3.2 on the macOS runner"; exit 1; fi'
+
+      - name: Build (under bash 3.2)
+        run: |
+          version=$(git describe --tags --always 2>/dev/null | sed 's/^v//' || echo 'dev')
+          /bin/bash ./dist/build.sh ./scripts/gitb.sh ./dist/gitb "$version"
+          chmod +x ./dist/gitb
+
+      - name: Install BATS
+        run: brew install bats-core
+
+      - name: Run BATS suite under system bash 3.2
+        # Force every `#!/usr/bin/env bash` (bats itself and its helpers) to
+        # resolve to the system bash 3.2 by putting a symlink first on PATH.
+        # The macOS image may already carry a Homebrew bash 5 on PATH, so this
+        # guarantees the suite genuinely exercises 3.2.
+        run: |
+          mkdir -p "$RUNNER_TEMP/bin32"
+          ln -sf /bin/bash "$RUNNER_TEMP/bin32/bash"
+          export PATH="$RUNNER_TEMP/bin32:$PATH"
+          bash --version | head -1
+          bash -c '[ "${BASH_VERSINFO[0]}" -eq 3 ] || { echo "not bash 3.x"; exit 1; }'
+          cd tests
+          bats ./*.bats
+
+      - name: Smoke test bundled gitb under bash 3.2
+        run: |
+          /bin/bash ./dist/gitb version
+          /bin/bash ./dist/gitb help

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,35 @@ jobs:
       - name: Smoke Test
         run: ./dist/gitb
 
+  bash32-syntax:
+    # Fast, deterministic bash 3.2 gate on Linux using the official bash:3.2
+    # Docker image: syntax-check every script and run the shim self-test under a
+    # genuine 3.2 interpreter. Complements the macOS job below (which runs the
+    # full functional suite under macOS's system bash 3.2 + BSD userland).
+    needs: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build bundle
+        run: |
+          version=$(git describe --tags --always 2>/dev/null | sed 's/^v//' || echo 'dev')
+          ./dist/build.sh ./scripts/gitb.sh ./dist/gitb "$version"
+          chmod +x ./dist/gitb
+
+      - name: Syntax + shim self-test under bash 3.2 (Docker)
+        run: |
+          docker run --rm -v "$PWD:/work" -w /work bash:3.2 bash -c '
+            major=${BASH_VERSINFO[0]}; minor=${BASH_VERSINFO[1]}
+            echo "container bash: $major.$minor"
+            if [ "$major" -ne 3 ] || [ "$minor" -ne 2 ]; then
+              echo "Expected bash 3.2 in the bash:3.2 image"; exit 1
+            fi
+            bash tests/bash32_compat_check.sh
+          '
+
   bash32:
     # The real bash 3.2 gate. macOS ships /bin/bash 3.2.57 (the oldest bash we
     # support), so run the whole suite under it — WITHOUT prepending Homebrew's

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,9 +64,16 @@ Aliases are colocated with the canonical name in the case pattern (`commit|c|co|
 
 `scripts/base.sh:86-93` rewrites every occurrence of `--help` / `-h` in `$@` to the literal token `help` before dispatch. This means each subcommand handler only has to look for `help`, not three spellings. `gitb commit --help`, `gitb commit -h`, and `gitb commit help` all hit the same branch.
 
-### Re-exec to Bash 4+
+### Bash 3.2 compatibility
 
-If `gitb` runs under Bash 3 (the macOS system bash), `scripts/gitb.sh:18-46` tries to `exec` a newer bash — first via `command -v bash`, then `brew --prefix bash`, then hardcoded Homebrew prefixes. Only when none works does it print the install hint. The bundle inherits this logic; the bash 3 path only ever produces the upgrade message, never tries to run the rest of the script.
+gitbasher targets Bash 3.2 — the version macOS ships as `/bin/bash` — so it runs on a stock Mac with no `brew install bash`. The features bash 4 added and we used are emulated for 3.2:
+
+- **Associative arrays** → a portable string-keyed map/set shim in `scripts/common.sh` (`gmap_set` / `gmap_get` / `gmap_has` / `gmap_inc` / `gmap_keys` / `gset_add`). Keys are hex-encoded into variable-name suffixes; values are stored verbatim via `printf -v` (never `eval`). Integer-keyed maps (menu tables, per-group accumulators) use plain indexed arrays instead.
+- **`${var,,}` / `${var^^}`** → `to_lower` / `to_upper` helpers (`tr`-based).
+- **`mapfile -t`** → `while IFS= read -r` loops.
+- **`read -i` (preloaded readline buffer)** → used on bash 4+, with a 3.2 fallback that shows the current value and keeps it on an empty submit.
+
+Only Bash < 3.2 is unsupported: `scripts/gitb.sh` then tries to `exec` a newer bash — first via `command -v bash`, then `brew --prefix bash`, then hardcoded Homebrew prefixes — and prints an install hint only when none works. The `bash32` CI job runs the whole test suite under macOS's real `/bin/bash` 3.2 to keep this guarantee honest.
 
 ### Stale lock detection
 
@@ -105,7 +112,7 @@ chmod +x ./dist/gitb
 End-to-end, `gitb wip up worktree` does this:
 
 1. Shell finds `gitb` on `PATH` (installed by npm or the install script). It is the bundled `dist/gitb`.
-2. The bash 4+ check passes (or re-execs).
+2. The bash 3.2+ check passes (or re-execs an older shell).
 3. The stale-lock check passes.
 4. `case "$1"` in the dispatch matches `wip|w` → calls `wip_script "${@:2}"` (`base.sh:124-126`).
 5. `wip_script` is the entry function defined in `scripts/wip.sh`. It parses subcommand args (`up`, `down`, …) and dispatches to `wip_up` / `wip_down`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for taking the time to contribute! This document describes how to set up 
 ```bash
 git clone https://github.com/maxbolgarin/gitbasher.git
 cd gitbasher
-# Run the dev version directly (Bash 4+ required)
+# Run the dev version directly (Bash 3.2+ required)
 bash scripts/gitb.sh --version
 ```
 
@@ -47,7 +47,7 @@ Aim for **no new** warnings. The CI bar is `severity: error`; widening to `sever
 
 ## Coding conventions
 
-- **Bash 4+ features are allowed** (`mapfile`, associative arrays, `${var,,}` etc.). The bundled binary re-execs to a newer Bash on macOS, so older Bash 3 paths only need to display the upgrade hint.
+- **Target Bash 3.2** (the version macOS ships as `/bin/bash`). Do **not** use bash 4-only features — no associative arrays (`declare -A`), `mapfile`/`readarray`, `${var,,}`/`${var^^}` case-folding, or `read -i`. Use the helpers in `scripts/common.sh` instead: the `gmap_*` / `gset_*` map/set shim, `to_lower` / `to_upper`, and `while IFS= read -r` loops. Plain indexed arrays are fine for integer-keyed data. The `bash32` CI job runs the full suite under macOS's real bash 3.2.
 - **Quote variables** in `git` invocations and any path/branch/ref handling, except where word-splitting is intentional (and document why with a comment).
 - **Prefer portable constructs** over GNU-only extensions. Tested examples:
   - `mapfile -t arr < <(cmd) ; [ ${#arr[@]} -gt 0 ] && cmd2 "${arr[@]}"` instead of `cmd | xargs -r cmd2`

--- a/FAQ.md
+++ b/FAQ.md
@@ -36,11 +36,13 @@ The active provider has no key in any of the slots gitbasher checks (env var →
 
 ## Bash and platform support
 
-### Why does gitbasher require Bash 4+?
+### What bash version does gitbasher need?
 
-It uses `mapfile`, associative arrays, `${var,,}` (case-folding), and other features that landed in bash 4.0 (2009). macOS still ships bash 3.2 by default for license reasons. Gitbasher detects this at startup and tries to re-exec under a newer bash from `command -v bash`, `brew --prefix bash`, or known Homebrew paths before falling back to a manual install hint.
+Bash 3.2 or newer. That's the version macOS still ships as `/bin/bash` (frozen at 3.2 for license reasons), so gitbasher runs out of the box on a stock Mac — no `brew install bash` required.
 
-If you can't install bash 4+, gitbasher won't run — there is no bash 3 fallback codepath.
+Bash 4-only features (`mapfile`, associative arrays, `${var,,}` case-folding, `read -i`) were removed in favor of bash 3.2-compatible equivalents: a small portable map/set shim in `scripts/common.sh`, `tr`-based case folding, and a graceful `read` fallback. Installing a newer bash is still nice-to-have — on bash 4+, prompts that come pre-filled with a value (editing an AI-suggested commit message, renaming a branch) let you edit the text in place; on bash 3.2 you retype the line or press Enter to keep the current value.
+
+Only genuinely ancient shells (bash < 3.2) are unsupported; for those, gitbasher tries to re-exec under a newer bash before printing an install hint.
 
 ### Does gitbasher work on Windows?
 

--- a/README.md
+++ b/README.md
@@ -949,9 +949,9 @@ Per-repo settings live in `.git/config` and need write access to that file (`chm
 <details>
 <summary><b>"Bad substitution" or bash errors</b></summary>
 
-`bash --version` must be 4.0+.
+`bash --version` must be 3.2+ — the version macOS ships as `/bin/bash` — so this is rare.
 
-- macOS: `brew install bash` (and optionally make it default: `sudo sh -c 'echo /opt/homebrew/bin/bash >> /etc/shells' && chsh -s /opt/homebrew/bin/bash`)
+- macOS: already ships bash 3.2; gitbasher runs on it natively (a newer bash via `brew install bash` only improves in-place line editing of prefilled prompts)
 - Ubuntu/Debian: `sudo apt update && sudo apt install --only-upgrade bash`
 </details>
 
@@ -960,8 +960,8 @@ Per-repo settings live in `.git/config` and need write access to that file (`chm
 
 | OS | Bash | Git | Install |
 |----|------|-----|---------|
-| Linux | 4.0+ | 2.23+ | `apt install bash git` |
-| macOS | 4.0+ | 2.23+ | `brew install bash git` |
+| Linux | 3.2+ | 2.23+ | `apt install bash git` |
+| macOS | 3.2+ (system) | 2.23+ | `brew install git` |
 | Windows | WSL | WSL | `wsl --install` then Linux steps |
 </details>
 

--- a/install.sh
+++ b/install.sh
@@ -73,10 +73,11 @@ if [ "${git_major:-0}" -lt 2 ] || { [ "${git_major:-0}" -eq 2 ] && [ "${git_mino
 fi
 
 bash_major=${BASH_VERSINFO[0]:-0}
-if [ "$bash_major" -lt 4 ]; then
-    warn "bash ${BASH_VERSION} detected; gitbasher requires bash 4.0+."
+bash_minor=${BASH_VERSINFO[1]:-0}
+if [ "$bash_major" -lt 3 ] || { [ "$bash_major" -eq 3 ] && [ "$bash_minor" -lt 2 ]; }; then
+    warn "bash ${BASH_VERSION} detected; gitbasher requires bash 3.2+."
     case "$(uname -s)" in
-        Darwin) warn "On macOS run: brew install bash" ;;
+        Darwin) warn "macOS ships bash 3.2 as /bin/bash; if this triggers, install a newer bash: brew install bash" ;;
         Linux)  warn "Update via your package manager (e.g. apt install --only-upgrade bash)" ;;
     esac
 fi

--- a/scripts/branch.sh
+++ b/scripts/branch.sh
@@ -639,8 +639,10 @@ function branch_script {
     detected_prefixes=""
     all_branches=$(git branch -a --format='%(refname:short)' 2>/dev/null | sed 's|origin/||g' | sort -u)
     if [ -n "$all_branches" ]; then
-        declare -A prefix_candidates
-        
+        # Collect prefix candidates into a plain array; `sort -u` dedupes them
+        # afterwards (no associative array needed — bash 3.2 compatible).
+        prefix_candidates=()
+
         while IFS= read -r branch; do
             if [ -n "$branch" ] && [[ "$branch" != "$main_branch" ]] && [[ "$branch" != "HEAD" ]]; then
                 # Extract prefix from branch name using common separators
@@ -648,21 +650,15 @@ function branch_script {
                     prefix="${BASH_REMATCH[1]}"
                     # Filter out very short or common prefixes
                     if [[ ${#prefix} -ge 2 ]] && [[ ! "$prefix" =~ ^(dev|tmp|old|new|test)$ ]]; then
-                        prefix_candidates["$prefix"]=1
+                        prefix_candidates+=("$prefix")
                     fi
                 fi
             fi
         done <<< "$all_branches"
-        
-        # Convert to sorted array
-        detected_prefixes_array=()
-        for prefix in "${!prefix_candidates[@]}"; do
-            detected_prefixes_array+=("$prefix")
-        done
-        
-        # Sort the array
-        if [ ${#detected_prefixes_array[@]} -gt 0 ]; then
-            IFS=$'\n' detected_prefixes_sorted=($(sort <<<"${detected_prefixes_array[*]}"))
+
+        # Sort and dedupe the collected prefixes
+        if [ ${#prefix_candidates[@]} -gt 0 ]; then
+            IFS=$'\n' detected_prefixes_sorted=($(printf '%s\n' "${prefix_candidates[@]}" | sort -u))
             unset IFS
             detected_prefixes="${detected_prefixes_sorted[*]}"
         fi
@@ -713,19 +709,20 @@ function branch_script {
         
         # Build the display array
         IFS=' ' read -r -a prefixes_array <<< "$all_prefixes"
-        declare -A prefixes_map
-        
+        # Keyed by 1-based option number, so a plain indexed array suffices.
+        prefixes_map=()
+
         res=""
         for i in "${!prefixes_array[@]}"; do
             option=$((i+1))
-            prefixes_map["$option"]="${prefixes_array[$i]}"
-            
+            prefixes_map[$option]="${prefixes_array[$i]}"
+
             res="$res$option. ${BOLD}${prefixes_array[$i]}${ENDCOLOR}|"
         done
-        
+
         # Add no prefix option
         no_prefix_option=$((${#prefixes_array[@]}+1))
-        prefixes_map["$no_prefix_option"]=""
+        prefixes_map[$no_prefix_option]=""
         
         echo -e "You can select one of the ${YELLOW}detected prefixes${ENDCOLOR}: $(echo $res | column -ts'|')"
 

--- a/scripts/cherry.sh
+++ b/scripts/cherry.sh
@@ -287,7 +287,11 @@ function choose_commits_interactive {
     local show_all=false
     
     # Get list of commits from source branch that are not in current branch
-    mapfile -t all_commits < <(git rev-list "${current_branch}..${source_branch}" --reverse)
+    # (portable read-loop instead of bash 4's mapfile)
+    all_commits=()
+    while IFS= read -r _commit; do
+        all_commits+=("$_commit")
+    done < <(git rev-list "${current_branch}..${source_branch}" --reverse)
     
     if [ ${#all_commits[@]} -eq 0 ]; then
         echo -e "${YELLOW}No commits to cherry-pick from '${source_branch}'.${ENDCOLOR}"

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -479,29 +479,29 @@ function order_split_groups_by_dependency {
 
     # Precompute each group's staged additions once (added lines only, minus
     # the +++ file header). Used as the haystack for whole-word name matches.
-    local -A added_text=()
+    gmap_clear added_text
     local scope f
     local -a farr
     for scope in "${split_group_keys[@]}"; do
         farr=()
-        while IFS= read -r f; do [ -n "$f" ] && farr+=("$f"); done <<< "${split_groups[$scope]}"
-        [ ${#farr[@]} -eq 0 ] && { added_text[$scope]=""; continue; }
-        added_text[$scope]=$(git -c core.quotePath=false diff --cached -- "${farr[@]}" 2>/dev/null \
-            | grep '^+' | grep -v '^+++' || true)
+        while IFS= read -r f; do [ -n "$f" ] && farr+=("$f"); done <<< "$(gmap_get split_groups "$scope")"
+        [ ${#farr[@]} -eq 0 ] && { gmap_set added_text "$scope" ""; continue; }
+        gmap_set added_text "$scope" "$(git -c core.quotePath=false diff --cached -- "${farr[@]}" 2>/dev/null \
+            | grep '^+' | grep -v '^+++' || true)"
     done
 
     # dep_score[S] = number of OTHER groups that reference S by name.
-    local -A dep_score=()
+    gmap_clear dep_score
     local s o
     for s in "${split_group_keys[@]}"; do
-        dep_score[$s]=0
+        gmap_set dep_score "$s" 0
         [ "$s" = "misc" ] && continue
         for o in "${split_group_keys[@]}"; do
             [ "$o" = "$s" ] && continue
             # -F: scope names can contain regex-special chars (dots, dashes).
             # -w: match the whole token so `net` doesn't match `network`.
-            if printf '%s' "${added_text[$o]}" | grep -qwF -- "$s"; then
-                dep_score[$s]=$(( ${dep_score[$s]} + 1 ))
+            if printf '%s' "$(gmap_get added_text "$o")" | grep -qwF -- "$s"; then
+                gmap_inc dep_score "$s"
             fi
         done
     done
@@ -511,7 +511,7 @@ function order_split_groups_by_dependency {
     local -a decorated=()
     local i=0 key sc
     for key in "${split_group_keys[@]}"; do
-        sc="${dep_score[$key]}"
+        sc="$(gmap_get dep_score "$key")"
         [ "$key" = "misc" ] && sc=-1
         decorated+=("$(printf '%d\t%05d\t%s' "$sc" "$i" "$key")")
         i=$((i + 1))

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -77,8 +77,8 @@ function stage_fast_changes {
 ### (feat, fix, refactor, test, docs, chore, build, ci, perf, style, revert)
 ### with its singular/plural/synonym forms.
 function is_redundant_scope {
-    local type_lower="${1,,}"
-    local scope_lower="${2,,}"
+    local type_lower; type_lower=$(to_lower "$1")
+    local scope_lower; scope_lower=$(to_lower "$2")
     [ -z "$scope_lower" ] && return 1
     case "$type_lower" in
         feat)     [[ "$scope_lower" =~ ^(feat|feats|feature|features)$ ]] && return 0 ;;
@@ -148,9 +148,9 @@ function detect_scopes_from_staged_files {
 
     if [ -n "$staged_files" ]; then
         # Count occurrences of each path token with depth tracking
-        local -A scope_counts
-        local -A scope_depths
-        
+        gmap_clear scope_counts
+        gmap_clear scope_depths
+
         # Only directory components contribute to scope candidates — filenames
         # are skipped so single root-level files (README.md, package.json, etc.)
         # don't generate noisy one-off scopes. Root files end up in the "misc"
@@ -165,7 +165,7 @@ function detect_scopes_from_staged_files {
                     component="${path_components[$i]}"
                     [ -z "$component" ] && continue
 
-                    component_lower="${component,,}"
+                    component_lower=$(to_lower "$component")
                     # Filter out generic containers and dependency/output dirs
                     # that are rarely meaningful as a per-commit scope. In a
                     # monorepo, the container dir (`services/`, `apps/`,
@@ -183,10 +183,11 @@ function detect_scopes_from_staged_files {
                         continue
                     fi
 
-                    scope_counts["$component_lower"]=$((${scope_counts["$component_lower"]:-0} + 1))
+                    gmap_inc scope_counts "$component_lower"
                     current_depth=$((i + 1))
-                    if [ -z "${scope_depths["$component_lower"]}" ] || [ $current_depth -lt ${scope_depths["$component_lower"]} ]; then
-                        scope_depths["$component_lower"]=$current_depth
+                    existing_depth=$(gmap_get scope_depths "$component_lower")
+                    if [ -z "$existing_depth" ] || [ $current_depth -lt "$existing_depth" ]; then
+                        gmap_set scope_depths "$component_lower" "$current_depth"
                     fi
                 done
             fi
@@ -194,21 +195,24 @@ function detect_scopes_from_staged_files {
         
         # Find maximum count to determine if we should filter out count=1 tokens
         max_count=0
-        for token in "${!scope_counts[@]}"; do
-            if [ ${scope_counts["$token"]} -gt $max_count ]; then
-                max_count=${scope_counts["$token"]}
+        while IFS= read -r token; do
+            [ -z "$token" ] && continue
+            token_count=$(gmap_get scope_counts "$token")
+            if [ "$token_count" -gt $max_count ]; then
+                max_count=$token_count
             fi
-        done
-        
+        done < <(gmap_keys scope_counts)
+
         # Count total unique tokens
-        total_unique_tokens=${#scope_counts[@]}
-        
+        total_unique_tokens=$(gmap_size scope_counts)
+
         # Collect and sort scopes
         detected_scopes_array=()
-        for token in "${!scope_counts[@]}"; do
-            count=${scope_counts["$token"]}
-            depth=${scope_depths["$token"]}
-            
+        while IFS= read -r token; do
+            [ -z "$token" ] && continue
+            count=$(gmap_get scope_counts "$token")
+            depth=$(gmap_get scope_depths "$token")
+
             # Apply count filter
             # If we have few unique tokens (≤ 7), include all regardless of count
             # If we have many tokens and max_count > 1, only include tokens with count > 1
@@ -224,8 +228,8 @@ function detect_scopes_from_staged_files {
                 # If all tokens have count=1, include all
                 detected_scopes_array+=("$count:$depth:$token")
             fi
-        done
-        
+        done < <(gmap_keys scope_counts)
+
         # Sort by count (descending), then by depth (ascending), then by token name
         if [ ${#detected_scopes_array[@]} -gt 0 ]; then
             # Separate filename tokens from directory tokens for better sorting
@@ -263,7 +267,7 @@ function detect_scopes_from_staged_files {
             # duplicates that collapse to the same clean name.
             final_scopes=()
             count=0
-            declare -A seen_norm=()
+            gmap_clear seen_norm
             for entry in "${detected_scopes_sorted[@]}"; do
                 if [ $count -ge 9 ]; then
                     break
@@ -271,8 +275,8 @@ function detect_scopes_from_staged_files {
                 token="${entry##*:}"  # Extract token after last colon
                 token=$(normalize_scope_name "$token")
                 [ -z "$token" ] && continue
-                [ -n "${seen_norm[$token]:-}" ] && continue
-                seen_norm["$token"]=1
+                gset_has seen_norm "$token" && continue
+                gset_add seen_norm "$token"
                 final_scopes+=("$token")
                 count=$((count + 1))
             done
@@ -307,8 +311,7 @@ function build_split_groups_from_staged {
     detect_scopes_from_staged_files
 
     # Re-declare globals fresh on each call
-    unset split_groups split_group_keys
-    declare -gA split_groups=()
+    gmap_clear split_groups
     split_group_keys=()
 
     if [ -z "$detected_scopes" ]; then
@@ -342,7 +345,7 @@ function build_split_groups_from_staged {
             [ "$i_inner" -eq "$last_idx_inner" ] && continue
             comp="${comps[$i_inner]}"
             [ -z "$comp" ] && continue
-            comp_lower="${comp,,}"
+            comp_lower=$(to_lower "$comp")
             comp_no_ext_lower="${comp_lower%.*}"
             [ -z "$comp_no_ext_lower" ] && comp_no_ext_lower="$comp_lower"
             # detected scopes are normalized (.github -> github), so normalize
@@ -366,7 +369,7 @@ function build_split_groups_from_staged {
         if [ -z "$assigned" ] && [ "$last_idx_inner" -gt 0 ]; then
             local stem="${comps[$last_idx_inner]}"
             stem="${stem%.*}"          # drop the extension
-            stem="${stem,,}"           # lowercase
+            stem=$(to_lower "$stem")   # lowercase
             # Strip leading/trailing separators (_deploy-production ->
             # deploy-production) so they don't leak into the scope and so the
             # generic-name check below sees the clean stem.
@@ -381,11 +384,11 @@ function build_split_groups_from_staged {
 
         [ -z "$assigned" ] && assigned="misc"
 
-        if [ -z "${split_groups[$assigned]:-}" ]; then
+        if ! gmap_has split_groups "$assigned"; then
             split_group_keys+=("$assigned")
-            split_groups[$assigned]="$file"
+            gmap_set split_groups "$assigned" "$file"
         else
-            split_groups[$assigned]+=$'\n'"$file"
+            gmap_set split_groups "$assigned" "$(gmap_get split_groups "$assigned")"$'\n'"$file"
         fi
     done <<< "$staged_files"
 
@@ -431,7 +434,7 @@ function consolidate_split_groups {
     [ ${#split_group_keys[@]} -le "$max" ] && return 0
 
     # --- Stage 1: re-bucket by first non-generic path component ---
-    local -A rebucket=()
+    gmap_clear rebucket
     local -a rebucket_keys=()
     local key file bucket comp_lower i last_idx
     local -a comps
@@ -443,7 +446,7 @@ function consolidate_split_groups {
             bucket=""
             for i in "${!comps[@]}"; do
                 [ "$i" -eq "$last_idx" ] && continue   # skip the filename
-                comp_lower="${comps[$i],,}"
+                comp_lower=$(to_lower "${comps[$i]}")
                 [ -z "$comp_lower" ] && continue
                 if [[ "$comp_lower" =~ ^(src|lib|libs|scripts|bin|node_modules|vendor|tmp|temp|cache|logs|log|services|apps|packages|modules|components|cmd|internal)$ ]]; then
                     continue
@@ -453,20 +456,19 @@ function consolidate_split_groups {
                 break
             done
             [ -z "$bucket" ] && bucket="misc"
-            if [ -z "${rebucket[$bucket]:-}" ]; then
+            if ! gmap_has rebucket "$bucket"; then
                 rebucket_keys+=("$bucket")
-                rebucket[$bucket]="$file"
+                gmap_set rebucket "$bucket" "$file"
             else
-                rebucket[$bucket]+=$'\n'"$file"
+                gmap_set rebucket "$bucket" "$(gmap_get rebucket "$bucket")"$'\n'"$file"
             fi
-        done <<< "${split_groups[$key]}"
+        done <<< "$(gmap_get split_groups "$key")"
     done
 
-    unset split_groups split_group_keys
-    declare -gA split_groups=()
+    gmap_clear split_groups
     split_group_keys=()
     for key in "${rebucket_keys[@]}"; do
-        split_groups[$key]="${rebucket[$key]}"
+        gmap_set split_groups "$key" "$(gmap_get rebucket "$key")"
         split_group_keys+=("$key")
     done
 
@@ -476,13 +478,13 @@ function consolidate_split_groups {
     local -a sized=()
     local n
     for key in "${split_group_keys[@]}"; do
-        n=$(printf '%s\n' "${split_groups[$key]}" | grep -c .)
+        n=$(printf '%s\n' "$(gmap_get split_groups "$key")" | grep -c .)
         sized+=("${n}"$'\t'"${key}")
     done
     IFS=$'\n' sized=($(printf '%s\n' "${sized[@]}" | sort -t$'\t' -k1,1nr -k2,2))
     unset IFS
 
-    local -A kept=()
+    gmap_clear kept
     local -a kept_keys=()
     local keep_limit=$((max - 1))
     local misc_files="" idx=0 entry
@@ -490,25 +492,24 @@ function consolidate_split_groups {
         key="${entry#*$'\t'}"
         if [ "$idx" -lt "$keep_limit" ] && [ "$key" != "misc" ]; then
             kept_keys+=("$key")
-            kept[$key]="${split_groups[$key]}"
+            gmap_set kept "$key" "$(gmap_get split_groups "$key")"
             idx=$((idx + 1))
         elif [ -z "$misc_files" ]; then
-            misc_files="${split_groups[$key]}"
+            misc_files="$(gmap_get split_groups "$key")"
         else
-            misc_files+=$'\n'"${split_groups[$key]}"
+            misc_files+=$'\n'"$(gmap_get split_groups "$key")"
         fi
     done
 
-    unset split_groups split_group_keys
-    declare -gA split_groups=()
+    gmap_clear split_groups
     split_group_keys=()
     for key in "${kept_keys[@]}"; do
-        split_groups[$key]="${kept[$key]}"
+        gmap_set split_groups "$key" "$(gmap_get kept "$key")"
         split_group_keys+=("$key")
     done
     if [ -n "$misc_files" ]; then
         split_group_keys+=("misc")
-        split_groups[misc]="$misc_files"
+        gmap_set split_groups "misc" "$misc_files"
     fi
     return 0
 }
@@ -538,7 +539,7 @@ function is_heuristic_weak {
     local max_size=0 n
     local s
     for s in "${split_group_keys[@]}"; do
-        n=$(printf '%s\n' "${split_groups[$s]}" | grep -c .)
+        n=$(printf '%s\n' "$(gmap_get split_groups "$s")" | grep -c .)
         [ "$n" -gt "$max_size" ] && max_size="$n"
     done
     local pct=$((max_size * 100 / total))
@@ -606,12 +607,12 @@ Output TSV (scope<TAB>file) for every staged file. No prose."
     ai_response=$(printf '%s' "$ai_response" | LC_ALL=C sed -e 's/^```[a-zA-Z]*$//' -e 's/^```$//')
 
     # Build a set of expected staged files for validation
-    local -A staged_set=()
+    gmap_clear staged_set
     while IFS= read -r f; do
-        [ -n "$f" ] && staged_set["$f"]=1
+        [ -n "$f" ] && gset_add staged_set "$f"
     done <<< "$staged_files"
 
-    local -A new_groups=()
+    gmap_clear new_groups
     local -a new_keys=()
     local line scope file tab_count
     local tab=$'\t'
@@ -635,13 +636,13 @@ Output TSV (scope<TAB>file) for every staged file. No prose."
         scope=$(printf '%s' "$scope" | LC_ALL=C tr '[:upper:]' '[:lower:]')
 
         # Reject files the model invented or paraphrased
-        [ -z "${staged_set[$file]:-}" ] && continue
+        gset_has staged_set "$file" || continue
 
-        if [ -z "${new_groups[$scope]:-}" ]; then
+        if ! gmap_has new_groups "$scope"; then
             new_keys+=("$scope")
-            new_groups[$scope]="$file"
+            gmap_set new_groups "$scope" "$file"
         else
-            new_groups[$scope]+=$'\n'"$file"
+            gmap_set new_groups "$scope" "$(gmap_get new_groups "$scope")"$'\n'"$file"
         fi
     done <<< "$ai_response"
 
@@ -649,7 +650,7 @@ Output TSV (scope<TAB>file) for every staged file. No prose."
     local total_assigned=0 total_staged
     local key
     for key in "${new_keys[@]}"; do
-        total_assigned=$((total_assigned + $(printf '%s\n' "${new_groups[$key]}" | grep -c .)))
+        total_assigned=$((total_assigned + $(printf '%s\n' "$(gmap_get new_groups "$key")" | grep -c .)))
     done
     total_staged=$(printf '%s\n' "$staged_files" | grep -c .)
     if [ "$total_assigned" -ne "$total_staged" ] || [ ${#new_keys[@]} -lt 1 ]; then
@@ -657,11 +658,10 @@ Output TSV (scope<TAB>file) for every staged file. No prose."
     fi
 
     # Replace globals with AI grouping
-    unset split_groups split_group_keys
-    declare -gA split_groups
+    gmap_clear split_groups
     split_group_keys=()
     for key in "${new_keys[@]}"; do
-        split_groups[$key]="${new_groups[$key]}"
+        gmap_set split_groups "$key" "$(gmap_get new_groups "$key")"
         split_group_keys+=("$key")
     done
 
@@ -697,18 +697,17 @@ function _stage_file_by_status {
 # key the map by that new path and treat it as an add. The old path is
 # recorded as a deletion so it gets removed from the index when restaged.
 function _capture_split_statuses {
-    unset _split_status_by_file
-    declare -gA _split_status_by_file=()
+    gmap_clear _split_status_by_file
     local line status old new
     while IFS=$'\t' read -r status old new; do
         [ -z "$status" ] && continue
         case "$status" in
             R*|C*)
-                _split_status_by_file[$old]="D"
-                _split_status_by_file[$new]="M"
+                gmap_set _split_status_by_file "$old" "D"
+                gmap_set _split_status_by_file "$new" "M"
                 ;;
             *)
-                _split_status_by_file[$old]="${status:0:1}"
+                gmap_set _split_status_by_file "$old" "${status:0:1}"
                 ;;
         esac
     done < <(git -c core.quotePath=false diff --name-status --cached)
@@ -790,7 +789,7 @@ function print_commit_type_menu {
 }
 
 function print_split_groups_preview {
-    local -A staged_status_by_file=()
+    gmap_clear staged_status_by_file
     local staged_diff status file new_file
     staged_diff=$(git -c core.quotePath=false diff --name-status --cached)
     while IFS=$'\t' read -r status file new_file; do
@@ -798,17 +797,17 @@ function print_split_groups_preview {
         if [[ "$status" == R* || "$status" == C* ]]; then
             [ -n "$new_file" ] && file="$new_file"
         fi
-        staged_status_by_file["$file"]="${status:0:1}"
+        gmap_set staged_status_by_file "$file" "${status:0:1}"
     done <<< "$staged_diff"
 
     echo -e "${YELLOW}Detected changes across ${#split_group_keys[@]} scopes:${ENDCOLOR}"
     local scope file_count file_color staged_status
     for scope in "${split_group_keys[@]}"; do
-        file_count=$(printf '%s\n' "${split_groups[$scope]}" | grep -c .)
+        file_count=$(printf '%s\n' "$(gmap_get split_groups "$scope")" | grep -c .)
         echo -e "  ${BLUE}${BOLD}${scope}${ENDCOLOR} ${GRAY}(${file_count} file(s))${ENDCOLOR}:"
         while IFS= read -r file; do
             [ -z "$file" ] && continue
-            staged_status="${staged_status_by_file[$file]}"
+            staged_status=$(gmap_get staged_status_by_file "$file")
             case "$staged_status" in
                 A) file_color="$GREEN" ;;
                 M) file_color="$YELLOW" ;;
@@ -816,7 +815,7 @@ function print_split_groups_preview {
                 *) file_color="$GRAY" ;;
             esac
             echo -e "    ${file_color}${file}${ENDCOLOR}"
-        done <<< "${split_groups[$scope]}"
+        done <<< "$(gmap_get split_groups "$scope")"
     done
 }
 
@@ -923,9 +922,11 @@ function perform_commit_split {
     # Snapshot stores STATUS<TAB>FILE per line so abort-restore can also
     # replay deletions correctly.
     : > "$snapshot_file"
+    local _snap_status
     while IFS= read -r f; do
         [ -z "$f" ] && continue
-        printf '%s\t%s\n' "${_split_status_by_file[$f]:-M}" "$f" >> "$snapshot_file"
+        _snap_status=$(gmap_get _split_status_by_file "$f"); [ -z "$_snap_status" ] && _snap_status="M"
+        printf '%s\t%s\n' "$_snap_status" "$f" >> "$snapshot_file"
     done <<< "$original_staged"
     # Restore staging if the user kills the process mid-split
     trap "_restore_split_snapshot '$snapshot_file'" INT TERM
@@ -957,7 +958,7 @@ function perform_commit_split {
             done <<< "$currently_staged"
         fi
 
-        files_str="${split_groups[$scope]}"
+        files_str="$(gmap_get split_groups "$scope")"
         files_array=()
         while IFS= read -r f; do
             [ -n "$f" ] && files_array+=("$f")
@@ -972,8 +973,10 @@ function perform_commit_split {
         # deletions (otherwise `git add` would re-add the worktree copy and
         # the index ends up empty for that scope, breaking AI generation).
         local stage_failed=0
+        local _stage_status
         for f in "${files_array[@]}"; do
-            if ! _stage_file_by_status "$f" "${_split_status_by_file[$f]:-M}"; then
+            _stage_status=$(gmap_get _split_status_by_file "$f"); [ -z "$_stage_status" ] && _stage_status="M"
+            if ! _stage_file_by_status "$f" "$_stage_status"; then
                 stage_failed=1
                 break
             fi
@@ -2146,16 +2149,9 @@ function commit_script {
     fi
     print_commit_type_menu "$step" "$_ai_available_for_menu"
 
-    declare -A types=(
-        [1]="feat"
-        [2]="fix"
-        [3]="refactor"
-        [4]="test"
-        [5]="build"
-        [6]="ci"
-        [7]="chore"
-        [8]="docs"
-    )
+    # Index 0 is an unused placeholder so the menu numbers (1-8) map directly
+    # to array indices; a plain indexed array keeps this bash 3.2 compatible.
+    local -a types=("" "feat" "fix" "refactor" "test" "build" "ci" "chore" "docs")
 
     while [ true ]; do
         read -n 1 -s choice

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -12,6 +12,155 @@ GRAY_ES="\x1b[37m"
 ENDCOLOR_ES="\x1b[0m"
 
 
+### ===== PORTABLE ASSOCIATIVE-ARRAY SHIM (bash 3.2+) =====
+### Bash 3.2 — the system bash on macOS — has no associative arrays, no
+### ${var,,} case-folding, and no mapfile. These helpers emulate a string-keyed
+### map/set on top of plain scalar variables so gitbasher runs everywhere
+### without a bash 4 dependency.
+###
+### Keys may contain any bytes; they are hex-encoded into safe variable-name
+### suffixes (_gmap_enc). Values are stored verbatim with `printf -v`, never
+### through `eval`, so arbitrary value content — newlines, quotes, $(...) — is
+### stored as inert data and never executed. Insertion order is preserved in a
+### newline-delimited key list, so keys must not contain literal newlines (true
+### at every call site, which reads keys with `read -r`).
+###
+### API:
+###   gmap_clear NAME            reset map (call before first use to drop stale state)
+###   gmap_set   NAME KEY VALUE  set / overwrite
+###   gmap_get   NAME KEY        print value ("" when absent)
+###   gmap_has   NAME KEY        return 0 when key present, 1 otherwise
+###   gmap_inc   NAME KEY        value := (value or 0) + 1
+###   gmap_keys  NAME            print keys, one per line, in insertion order
+###   gmap_size  NAME            print number of keys
+###   gset_add / gset_has        set wrappers (value is always 1)
+
+### Hex-encode a string into [0-9a-f]* for use inside a variable name.
+### Byte-exact and locale-independent: `local LC_ALL=C` forces byte semantics
+### for the slice/length operators, and `& 0xff` masks any sign extension so
+### every byte yields exactly two hex digits (self-delimiting, collision-free).
+### Result is returned in _gmap_enc_out (no subshell, for speed in tight loops).
+# $1: string to encode
+function _gmap_enc {
+    local LC_ALL=C
+    local _s="$1" _out="" _i _n
+    for (( _i = 0; _i < ${#_s}; _i++ )); do
+        printf -v _n '%d' "'${_s:_i:1}"
+        printf -v _n '%02x' "$(( _n & 0xff ))"
+        _out="$_out$_n"
+    done
+    _gmap_enc_out="$_out"
+}
+
+### Remove every entry of a map and its key list (also used to initialize a
+### map and drop any stale state left by an earlier call with the same name).
+# $1: map name
+function gmap_clear {
+    local _hm _k _hk
+    _gmap_enc "$1"; _hm="$_gmap_enc_out"
+    while IFS= read -r _k; do
+        [ -z "$_k" ] && continue
+        _gmap_enc "$_k"; _hk="$_gmap_enc_out"
+        unset "_gmapH_${_hm}_${_hk}"
+    done < <(gmap_keys "$1")
+    unset "_gmapKL_${_hm}"
+}
+
+### Set (or overwrite) the value for a key.
+# $1: map name  $2: key  $3: value
+function gmap_set {
+    local _hm _hk _vn _kln _exists _cur
+    _gmap_enc "$1"; _hm="$_gmap_enc_out"
+    _gmap_enc "$2"; _hk="$_gmap_enc_out"
+    _vn="_gmapH_${_hm}_${_hk}"
+    _kln="_gmapKL_${_hm}"
+    eval "_exists=\${${_vn}+x}"
+    if [ -z "$_exists" ]; then
+        eval "_cur=\${${_kln}-}"
+        printf -v "$_kln" '%s%s\n' "$_cur" "$2"
+    fi
+    printf -v "$_vn" '%s' "$3"
+}
+
+### Print the value stored for a key, or nothing when the key is absent.
+# $1: map name  $2: key
+function gmap_get {
+    local _hm _hk _vn
+    _gmap_enc "$1"; _hm="$_gmap_enc_out"
+    _gmap_enc "$2"; _hk="$_gmap_enc_out"
+    _vn="_gmapH_${_hm}_${_hk}"
+    eval "printf '%s' \"\${${_vn}-}\""
+}
+
+### Return 0 when the key exists in the map (even with an empty value).
+# $1: map name  $2: key
+function gmap_has {
+    local _hm _hk _vn _exists
+    _gmap_enc "$1"; _hm="$_gmap_enc_out"
+    _gmap_enc "$2"; _hk="$_gmap_enc_out"
+    _vn="_gmapH_${_hm}_${_hk}"
+    eval "_exists=\${${_vn}+x}"
+    [ -n "$_exists" ]
+}
+
+### Increment the integer value of a key (absent key counts as 0). Done without
+### a subshell so it stays cheap inside per-file loops.
+# $1: map name  $2: key
+function gmap_inc {
+    local _hm _hk _vn _kln _exists _cur
+    _gmap_enc "$1"; _hm="$_gmap_enc_out"
+    _gmap_enc "$2"; _hk="$_gmap_enc_out"
+    _vn="_gmapH_${_hm}_${_hk}"
+    _kln="_gmapKL_${_hm}"
+    eval "_exists=\${${_vn}+x}"
+    if [ -z "$_exists" ]; then
+        eval "_cur=\${${_kln}-}"
+        printf -v "$_kln" '%s%s\n' "$_cur" "$2"
+        _cur=0
+    else
+        eval "_cur=\${${_vn}}"
+    fi
+    printf -v "$_vn" '%s' "$(( _cur + 1 ))"
+}
+
+### Print the map's keys, one per line, in insertion order.
+# $1: map name
+function gmap_keys {
+    local _hm
+    _gmap_enc "$1"; _hm="$_gmap_enc_out"
+    eval "printf '%s' \"\${_gmapKL_${_hm}-}\""
+}
+
+### Print the number of keys in the map. Always exits 0 (grep -c returns 1 on
+### an empty map, which would trip `set -e` at the call site).
+# $1: map name
+function gmap_size {
+    local _n
+    _n=$(gmap_keys "$1" | grep -c .)
+    printf '%s' "$_n"
+}
+
+### Set membership helpers (a set is just a map whose values are all 1).
+function gset_add { gmap_set "$1" "$2" 1; }
+function gset_has { gmap_has "$1" "$2"; }
+
+
+### ===== CASE-FOLDING HELPERS (bash 3.2+) =====
+### Replacements for bash 4's ${var,,} / ${var^^} expansions.
+
+### Print the argument lowercased.
+# $1: string
+function to_lower {
+    printf '%s' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]'
+}
+
+### Print the argument uppercased.
+# $1: string
+function to_upper {
+    printf '%s' "$1" | LC_ALL=C tr '[:lower:]' '[:upper:]'
+}
+
+
 ### ===== UX STYLE GUIDE =====
 ### All user-facing text in gitbasher follows these rules. Reviewers and future
 ### contributors: please keep new strings consistent with this guide.
@@ -538,7 +687,22 @@ function read_editable_input {
     bind '"\e": "\C-a\C-k\C-m"' 2>/dev/null || true
 
     if [ $# -ge 3 ]; then
-        IFS= read -r -e -p "$_prompt" -i "$3" "$_var"
+        if ((BASH_VERSINFO[0] >= 4)); then
+            # bash 4+: preload the editable buffer so the user edits in place.
+            IFS= read -r -e -p "$_prompt" -i "$3" "$_var"
+        else
+            # bash 3.2 has no `read -i` to preload readline. Degrade gracefully:
+            # show the current value and keep it when the user submits an empty
+            # line (retype the line to change it).
+            local _reply _hint=""
+            [ -n "$3" ] && _hint="[$3] "
+            IFS= read -r -e -p "${_prompt}${_hint}" _reply
+            if [ -z "$_reply" ]; then
+                printf -v "$_var" '%s' "$3"
+            else
+                printf -v "$_var" '%s' "$_reply"
+            fi
+        fi
     else
         IFS= read -r -e -p "$_prompt" "$_var"
     fi
@@ -1006,7 +1170,7 @@ function print_configuration {
         # legacy env > legacy config) is encoded in get_ai_api_key_source.
         local ai_key_tag
         case "$(get_ai_api_key_source)" in
-            env-provider)    ai_key_tag="${CYAN}(env: GITB_AI_API_KEY_${ai_provider^^})${ENDCOLOR}" ;;
+            env-provider)    ai_key_tag="${CYAN}(env: GITB_AI_API_KEY_$(to_upper "$ai_provider"))${ENDCOLOR}" ;;
             env-legacy)      ai_key_tag="${CYAN}(env: GITB_AI_API_KEY, legacy)${ENDCOLOR}" ;;
             local-provider)  ai_key_tag="${BLUE}(project)${ENDCOLOR}" ;;
             global-provider) ai_key_tag="${PURPLE}(global)${ENDCOLOR}" ;;

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -510,6 +510,21 @@ function print_help_row {
 ### ===== KEYBOARD INPUT HELPERS =====
 ### Handle case-insensitive input and alternative keyboard layouts (e.g. Russian)
 
+### bash 3.2's `read -t` rejects fractional timeouts (sub-second timeouts are
+### bash 4+). Poll at 0.01s on bash 4+, and at 1s on bash 3.2 for the
+### escape-sequence drain in read_key — that loop breaks as soon as the
+### sequence terminator arrives, so only a lone Esc waits the full second.
+if ((BASH_VERSINFO[0] >= 4)); then GITB_READ_POLL="0.01"; else GITB_READ_POLL="1"; fi
+
+### Best-effort: discard any buffered terminal input without blocking. bash 3.2
+### has no non-blocking sub-second read, so it skips draining there rather than
+### stalling the UI for a full second after each keystroke.
+function drain_pending_input {
+    ((BASH_VERSINFO[0] < 4)) && return 0
+    local _d
+    while IFS= read -r -s -n 1 -t 0.01 _d 2>/dev/null; do :; done
+}
+
 ### Map of Russian keyboard layout to Latin equivalents (same physical keys)
 # Russian: й ц у к е н г ш щ з х ъ ф ы в а п р о л д ж э я ч с м и т ь б ю
 # Latin:   q w e r t y u i o p [ ] a s d f g h j k l ; ' z x c v b n m , .
@@ -634,7 +649,7 @@ function read_key {
 
             # Arrow keys and similar controls arrive as escape sequences. Drain the
             # remaining bytes now so they are not echoed as invalid input later.
-            while IFS= read -r -s -n 1 -t 0.01 _esc_part; do
+            while IFS= read -r -s -n 1 -t "$GITB_READ_POLL" _esc_part; do
                 _esc_rest="${_esc_rest}${_esc_part}"
                 if [[ "$_esc_rest" =~ ^(\[|O).*[@-~]$ ]] || [ ${#_esc_rest} -ge 8 ]; then
                     break
@@ -731,8 +746,7 @@ function read_silent_input {
         # ESC: drain any follow-on bytes (arrow keys etc.) and cancel
         if [ "$_char" = $'\e' ]; then
             _input=""
-            local _drain
-            while IFS= read -r -s -n 1 -t 0.01 _drain; do :; done
+            drain_pending_input
             break
         fi
         # Backspace / DEL
@@ -1309,7 +1323,7 @@ function choose {
             read -p "$read_prefix" -n 1 -s choice
             # Drain trailing newline so users who press "1<Enter>" don't leak
             # the newline into the next read (e.g. worktree move's path prompt).
-            read -t 0.01 -s _choose_drain 2>/dev/null
+            drain_pending_input
         fi
 
         if [ "$choice" == "0" ] || [ "$choice" == "00" ]; then

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -56,16 +56,9 @@ function set_sep {
     echo -e "8. type${YELLOW}@${ENDCOLOR}name"
     echo "0. Exit"
     
-    declare -A seps=(
-            [1]="/"
-            [2]="_"
-            [3]="-"
-            [4]="."
-            [5]=","
-            [6]="+"
-            [7]="="
-            [8]="@"
-        )
+    # Index 0 is an unused placeholder so menu numbers (1-8) map directly to
+    # array indices; a plain indexed array keeps this bash 3.2 compatible.
+    local -a seps=("" "/" "_" "-" "." "," "+" "=" "@")
 
     while [ true ]; do
         read -n 1 -s choice

--- a/scripts/gitb.sh
+++ b/scripts/gitb.sh
@@ -43,15 +43,19 @@ if [[ "$git_check" == *"fatal: not a git repository"* ]]; then
 fi
 
 
-### Cannot use bash version less than 4 because of many features that was added to language in that version
-if ((BASH_VERSINFO[0] < 4)); then
+### gitbasher targets bash 3.2+ — the version that ships as /bin/bash on macOS.
+### Only genuinely ancient shells (bash < 3.2) lack the features we rely on
+### (printf -v, array += append, [[ =~ ]] / BASH_REMATCH, C-style for). For
+### those, try to re-exec under a newer bash before giving up.
+if ((BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 2))); then
     # Try to re-exec with a newer bash. Order:
-    #   1. PATH-resolved bash that reports >= 4 (covers MacPorts, nix, custom prefixes, Linux upgrades)
+    #   1. PATH-resolved bash that reports >= 3.2 (covers MacPorts, nix, custom prefixes, Linux upgrades)
     #   2. Homebrew-managed bash (handles Apple Silicon vs Intel and custom HOMEBREW_PREFIX)
     #   3. Hardcoded common paths as a final fallback
+    _gitb_min='((BASH_VERSINFO[0] > 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] >= 2)))'
     _gitb_candidate=$(command -v bash 2>/dev/null)
     if [ -n "$_gitb_candidate" ] && [ -x "$_gitb_candidate" ] \
-       && "$_gitb_candidate" -c '((BASH_VERSINFO[0] >= 4))' >/dev/null 2>&1; then
+       && "$_gitb_candidate" -c "$_gitb_min" >/dev/null 2>&1; then
         exec "$_gitb_candidate" "$0" "$@"
     fi
     if command -v brew >/dev/null 2>&1; then
@@ -63,13 +67,13 @@ if ((BASH_VERSINFO[0] < 4)); then
     for _gitb_candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
         [ -x "$_gitb_candidate" ] && exec "$_gitb_candidate" "$0" "$@"
     done
-    unset _gitb_candidate
+    unset _gitb_candidate _gitb_min
 
-    printf "Sorry, you need at least bash-4.0 to run gitbasher.\n\n"
+    printf "Sorry, you need at least bash-3.2 to run gitbasher.\n\n"
     printf "Linux (Debian/Ubuntu):\n    sudo apt update && sudo apt install --only-upgrade bash\n\n"
-    printf "macOS:\n    1) Install Homebrew (if missing):\n       /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"\n    2) Install newer bash:\n       brew install bash\n    3) Optional: make it your default shell (then restart Terminal):\n       sudo sh -c 'echo /opt/homebrew/bin/bash >> /etc/shells' && chsh -s /opt/homebrew/bin/bash\n\n"
-    printf "Or run gitb explicitly with the newer bash when installed:\n    /opt/homebrew/bin/bash $0 \"\$@\"\n\n"
-    exit 1; 
+    printf "macOS already ships bash 3.2 as /bin/bash, so this should be rare.\n"
+    printf "If you are on an older system, install a newer bash via Homebrew:\n    brew install bash\n\n"
+    exit 1;
 fi
 
 

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -4,14 +4,17 @@
 # Run it before using gitbasher
 
 ### Consts for colors
-RED="\e[31m"
-GREEN="\e[32m"
-YELLOW="\e[33m"
-BLUE="\e[34m"
-PURPLE="\e[35m"
-CYAN="\e[36m"
-GRAY="\e[37m"
-ENDCOLOR="\e[0m"
+# Use octal \033 (not \e): both `echo -e` and `printf '%b'` interpret \033 on
+# every bash, whereas \e is a bash extension that bash 3.2's `printf %b` leaves
+# literal — which would emit raw "\e[31m" to the terminal there.
+RED="\033[31m"
+GREEN="\033[32m"
+YELLOW="\033[33m"
+BLUE="\033[34m"
+PURPLE="\033[35m"
+CYAN="\033[36m"
+GRAY="\033[37m"
+ENDCOLOR="\033[0m"
 BOLD="\033[1m"
 NORMAL="\033[0m"
 

--- a/scripts/merge.sh
+++ b/scripts/merge.sh
@@ -382,7 +382,8 @@ function resolve_conflicts {
                     elif [ "$choice_resolve" == "2" ]; then
                         echo -e "${YELLOW}Force accepting incoming changes...${ENDCOLOR}"
                         # Force remove files that don't exist in theirs (portable across GNU/BSD)
-                        mapfile -t _deleted < <(git ls-files --deleted)
+                        _deleted=()
+                        while IFS= read -r _df; do [ -n "$_df" ] && _deleted+=("$_df"); done < <(git ls-files --deleted)
                         [ ${#_deleted[@]} -gt 0 ] && git rm -- "${_deleted[@]}" 2>/dev/null
                         unset _deleted
                         git checkout --theirs . 2>/dev/null
@@ -461,7 +462,8 @@ function resolve_conflicts {
                     elif [ "$choice_resolve" == "2" ]; then
                         echo -e "${YELLOW}Force accepting current changes...${ENDCOLOR}"
                         # Force remove files that don't exist in ours (portable across GNU/BSD)
-                        mapfile -t _deleted < <(git ls-files --deleted)
+                        _deleted=()
+                        while IFS= read -r _df; do [ -n "$_df" ] && _deleted+=("$_df"); done < <(git ls-files --deleted)
                         [ ${#_deleted[@]} -gt 0 ] && git rm -- "${_deleted[@]}" 2>/dev/null
                         unset _deleted
                         git checkout --ours . 2>/dev/null

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -636,7 +636,8 @@ function rebase_conflicts {
                     elif [ "$choice_resolve" == "2" ]; then
                         echo -e "${YELLOW}Force accepting incoming changes...${ENDCOLOR}"
                         # Force remove files that don't exist in theirs (portable across GNU/BSD)
-                        mapfile -t _deleted < <(git ls-files --deleted)
+                        _deleted=()
+                        while IFS= read -r _df; do [ -n "$_df" ] && _deleted+=("$_df"); done < <(git ls-files --deleted)
                         [ ${#_deleted[@]} -gt 0 ] && git rm -- "${_deleted[@]}" 2>/dev/null
                         unset _deleted
                         git checkout --theirs . 2>/dev/null

--- a/scripts/squash.sh
+++ b/scripts/squash.sh
@@ -234,11 +234,12 @@ function squash_parse_ai_plan {
     local response="$1"
     local expected_hashes_str="$2"
 
-    # Reset globals
+    # Reset globals. These are keyed by 1-based group number, so plain indexed
+    # arrays (bash 3.2 compatible) work in place of associative arrays.
     unset squash_group_commits squash_group_message squash_group_body
-    declare -gA squash_group_commits
-    declare -gA squash_group_message
-    declare -gA squash_group_body
+    declare -ga squash_group_commits=()
+    declare -ga squash_group_message=()
+    declare -ga squash_group_body=()
     squash_group_count=0
     squash_parse_error=""
 
@@ -285,16 +286,16 @@ function squash_parse_ai_plan {
     fi
 
     # Build expected-hash sets
-    local -A expected_set=()
+    gmap_clear expected_set
     local -a expected_order=()
     local h
     for h in $expected_hashes_str; do
-        expected_set["$h"]=1
+        gset_add expected_set "$h"
         expected_order+=("$h")
     done
 
     local seen=()
-    declare -A seen_set=()
+    gmap_clear seen_set
     local current_group=0
     local g
     for ((g = 0; g < groups_count; g++)); do
@@ -327,15 +328,15 @@ function squash_parse_ai_plan {
         local validated="" c
         while IFS= read -r c; do
             [ -z "$c" ] && continue
-            if [ -z "${expected_set[$c]:-}" ]; then
+            if ! gset_has expected_set "$c"; then
                 squash_parse_error="group $one_idx references unknown commit '$c' (not in input range)"
                 return 1
             fi
-            if [ -n "${seen_set[$c]:-}" ]; then
+            if gset_has seen_set "$c"; then
                 squash_parse_error="group $one_idx reuses commit '$c' already assigned to an earlier group"
                 return 1
             fi
-            seen_set["$c"]=1
+            gset_add seen_set "$c"
             seen+=("$c")
             validated+="${validated:+ }$c"
         done <<< "$commits_arr"
@@ -494,11 +495,11 @@ function squash_run_ai_grouping {
         chunk_idx=$((chunk_idx + 1))
     done
 
-    # Copy accumulators back into the per-group globals.
+    # Copy accumulators back into the per-group globals (1-based indexed arrays).
     unset squash_group_commits squash_group_message squash_group_body
-    declare -gA squash_group_commits
-    declare -gA squash_group_message
-    declare -gA squash_group_body
+    declare -ga squash_group_commits=()
+    declare -ga squash_group_message=()
+    declare -ga squash_group_body=()
     squash_group_count=${#final_commits[@]}
 
     local g_idx

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -106,7 +106,7 @@ function uninstall_script {
     # Trim leading/trailing whitespace; case-insensitive match against "delete"
     confirm_input="${confirm_input#"${confirm_input%%[![:space:]]*}"}"
     confirm_input="${confirm_input%"${confirm_input##*[![:space:]]}"}"
-    if [ "${confirm_input,,}" != "delete" ]; then
+    if [ "$(to_lower "$confirm_input")" != "delete" ]; then
         echo
         echo -e "${YELLOW}Cancelled — nothing was changed.${ENDCOLOR}"
         exit 0

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -209,25 +209,22 @@ function prompt_worktree_branch {
     detected_prefixes=""
     all_branches=$(git branch -a --format='%(refname:short)' 2>/dev/null | sed 's|origin/||g' | sort -u)
     if [ -n "$all_branches" ]; then
-        declare -A prefix_candidates
+        # Collect prefix candidates into a plain array; `sort -u` dedupes them
+        # afterwards (no associative array needed — bash 3.2 compatible).
+        prefix_candidates=()
         while IFS= read -r branch; do
             if [ -n "$branch" ] && [[ "$branch" != "$main_branch" ]] && [[ "$branch" != "HEAD" ]]; then
                 if [[ "$branch" =~ ^([a-zA-Z0-9]+)[-_/](.+)$ ]]; then
                     prefix="${BASH_REMATCH[1]}"
                     if [[ ${#prefix} -ge 2 ]] && [[ ! "$prefix" =~ ^(dev|tmp|old|new|test)$ ]]; then
-                        prefix_candidates["$prefix"]=1
+                        prefix_candidates+=("$prefix")
                     fi
                 fi
             fi
         done <<< "$all_branches"
 
-        detected_prefixes_array=()
-        for prefix in "${!prefix_candidates[@]}"; do
-            detected_prefixes_array+=("$prefix")
-        done
-
-        if [ ${#detected_prefixes_array[@]} -gt 0 ]; then
-            IFS=$'\n' detected_prefixes_sorted=($(sort <<<"${detected_prefixes_array[*]}"))
+        if [ ${#prefix_candidates[@]} -gt 0 ]; then
+            IFS=$'\n' detected_prefixes_sorted=($(printf '%s\n' "${prefix_candidates[@]}" | sort -u))
             unset IFS
             detected_prefixes="${detected_prefixes_sorted[*]}"
         fi
@@ -268,17 +265,18 @@ function prompt_worktree_branch {
         echo -e "Press Enter to skip the prefix, or 0 to exit without changes"
 
         IFS=' ' read -r -a prefixes_array <<< "$all_prefixes"
-        declare -A prefixes_map
+        # Keyed by 1-based option number, so a plain indexed array suffices.
+        local -a prefixes_map=()
 
         local res=""
         for i in "${!prefixes_array[@]}"; do
             local option=$((i+1))
-            prefixes_map["$option"]="${prefixes_array[$i]}"
+            prefixes_map[$option]="${prefixes_array[$i]}"
             res="$res$option. ${BOLD}${prefixes_array[$i]}${ENDCOLOR}|"
         done
 
         local no_prefix_option=$((${#prefixes_array[@]}+1))
-        prefixes_map["$no_prefix_option"]=""
+        prefixes_map[$no_prefix_option]=""
 
         echo -e "You can select one of the ${YELLOW}detected prefixes${ENDCOLOR}: $(echo $res | column -ts'|')"
 

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -782,7 +782,7 @@ function worktree_manage {
 
     local choice
     read -n 1 -s choice
-    read -t 0.01 -s _wt_drain 2>/dev/null
+    drain_pending_input
 
     case "$choice" in
         1) _do_worktree_move ;;
@@ -966,7 +966,7 @@ function worktree_script {
 
         local choice
         read -n 1 -s choice
-        read -t 0.01 -s _wt_drain 2>/dev/null
+        drain_pending_input
 
         case "$choice" in
             1) add_mode="true";;
@@ -989,7 +989,7 @@ function worktree_script {
 
             local source_choice
             read -n 1 -s source_choice
-            read -t 0.01 -s _wt_drain 2>/dev/null
+            drain_pending_input
 
             case "$source_choice" in
                 1) add_source="current";;

--- a/site/src/components/Faq.astro
+++ b/site/src/components/Faq.astro
@@ -6,7 +6,7 @@ const faqs = [
   },
   {
     q: 'What platforms does it run on?',
-    a: 'Linux, macOS, and Windows under WSL. Requires bash 4+ (uses mapfile, associative arrays, case-folding). On macOS gitbasher detects the default bash 3.2 and re-execs under a newer bash from Homebrew automatically.',
+    a: 'Linux, macOS, and Windows under WSL. Runs on bash 3.2+, the version macOS ships as /bin/bash — so it works on a stock Mac with no extra install. A newer bash is optional and only improves in-place editing of pre-filled prompts.',
   },
   {
     q: 'Does it interfere with my existing git workflow?',

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -22,7 +22,7 @@ const installCmd = 'curl -fsSL https://raw.githubusercontent.com/maxbolgarin/git
     </div>
 
     <p class="hero-meta">
-      Linux · macOS · WSL · requires bash 4+ ·
+      Linux · macOS · WSL · runs on bash 3.2+ ·
       <a href="#install">other install methods</a>
     </p>
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -95,7 +95,7 @@ bats test_sanitization.bats --filter "sanitize_git_name: accepts valid branch na
 
 ### Prerequisites
 
-- Bash 4.0 or higher
+- Bash 3.2 or higher
 - Git 2.23 or higher
 - BATS (will be installed automatically by run_tests.sh)
 
@@ -249,7 +249,7 @@ bats test_sanitization.bats --filter "test name"
 1. **Test repo not cleaned up**: Make sure `teardown()` runs
 2. **Git config missing**: Check `setup_test_repo()` sets user.name/email
 3. **Working directory wrong**: Use `cd "$TEST_REPO"` in setup
-4. **Bash version**: Requires Bash 4.0+
+4. **Bash version**: Requires Bash 3.2+
 
 ## Coverage Goals
 

--- a/tests/bash32_compat_check.sh
+++ b/tests/bash32_compat_check.sh
@@ -35,6 +35,17 @@ if [ -f "$here/dist/gitb" ]; then
     fi
 fi
 
+# 1b. Guard against non-ASCII bytes in @test descriptions. bats mangles them
+# into broken function names under bash 3.2 and silently drops those tests
+# ("executed N instead of expected M"). Keep descriptions ASCII; put any
+# non-ASCII fixtures in the test body instead.
+nonascii=$(LC_ALL=C grep -n '^@test .*[^ -~]' "$here"/tests/*.bats 2>/dev/null || true)
+if [ -n "$nonascii" ]; then
+    echo "NON-ASCII @test descriptions (break bats under bash 3.2):"
+    printf '%s\n' "$nonascii"
+    fail=1
+fi
+
 # 2. Load the helpers and exercise them.
 # shellcheck disable=SC1091
 source "$here/scripts/common.sh"

--- a/tests/bash32_compat_check.sh
+++ b/tests/bash32_compat_check.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Bash 3.2 compatibility checks.
+#
+# Two things are verified here:
+#   1. Every shell script parses (`bash -n`) — the real guard against an
+#      accidental bash 4-only construct sneaking back in.
+#   2. The portable map/set shim and case-folding helpers in scripts/common.sh
+#      behave correctly.
+#
+# Designed to run under bash 3.2 in CI (the official `bash:3.2` Docker image),
+# but it also runs fine under any newer bash for a quick local check:
+#   tests/bash32_compat_check.sh
+# or under real 3.2 locally:
+#   docker run --rm -v "$PWD:/work" -w /work bash:3.2 bash tests/bash32_compat_check.sh
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "bash: $BASH_VERSION"
+
+fail=0
+
+# 1. Syntax-check every shell file we ship.
+for f in "$here"/scripts/*.sh "$here"/install.sh "$here"/dist/build.sh; do
+    if ! bash -n "$f"; then
+        echo "SYNTAX FAIL: $f"
+        fail=1
+    fi
+done
+# The bundle only exists after a build; check it when present.
+if [ -f "$here/dist/gitb" ]; then
+    if ! bash -n "$here/dist/gitb"; then
+        echo "SYNTAX FAIL: dist/gitb"
+        fail=1
+    fi
+fi
+
+# 2. Load the helpers and exercise them.
+# shellcheck disable=SC1091
+source "$here/scripts/common.sh"
+
+_t() {
+    if [ "$2" = "$3" ]; then
+        echo "ok  - $1"
+    else
+        echo "NOT - $1 : got [$2] want [$3]"
+        fail=1
+    fi
+}
+
+# Map with awkward keys (slashes, dots) and an awkward value (embedded newline).
+gmap_clear m
+gmap_set m "services/auth" $'a\nb'
+gmap_set m ".github" "x"
+_t "map: slash key, newline value" "$(gmap_get m 'services/auth')" $'a\nb'
+_t "map: dot key" "$(gmap_get m '.github')" "x"
+gmap_has m ".github"; _t "map: has present" "$?" "0"
+gmap_has m "absent"; _t "map: has absent" "$?" "1"
+_t "map: get absent is empty" "$(gmap_get m 'absent')" ""
+_t "map: size" "$(gmap_size m)" "2"
+
+# A value containing shell metacharacters must be stored inert, never executed.
+gmap_clear inj
+gmap_set inj "k" 'x $(touch /tmp/gitb_pwn) `id` ;rm'
+_t "map: value injection is inert" "$(gmap_get inj 'k')" 'x $(touch /tmp/gitb_pwn) `id` ;rm'
+[ -e /tmp/gitb_pwn ] && { echo "NOT - injection executed!"; fail=1; }
+
+# Counters.
+gmap_clear c
+gmap_inc c "foo.bar"; gmap_inc c "foo.bar"; gmap_inc c "foo.bar"
+_t "map: inc 3x" "$(gmap_get c 'foo.bar')" "3"
+
+# Clear really clears, including emptying size.
+gmap_clear m
+_t "map: cleared size" "$(gmap_size m)" "0"
+_t "map: cleared get" "$(gmap_get m 'services/auth')" ""
+
+# Insertion-order key iteration.
+gmap_clear k
+gmap_set k "b" 1; gmap_set k "a" 1; gmap_set k "c" 1
+_t "map: keys in insertion order" "$(gmap_keys k)" $'b\na\nc'
+
+# Map names that are prefixes of one another must not collide.
+gmap_clear staged
+gmap_clear staged_status
+gmap_set staged "x" "1"
+gmap_set staged_status "x" "2"
+_t "map: no name-prefix collision A" "$(gmap_get staged 'x')" "1"
+_t "map: no name-prefix collision B" "$(gmap_get staged_status 'x')" "2"
+
+# Set helpers.
+gmap_clear s
+gset_add s "x/y"
+gset_has s "x/y"; _t "set: member" "$?" "0"
+gset_has s "z"; _t "set: non-member" "$?" "1"
+
+# Case folding.
+_t "to_lower" "$(to_lower 'AbC/DeF')" "abc/def"
+_t "to_upper" "$(to_upper 'AbC/DeF')" "ABC/DEF"
+
+if [ "$fail" -ne 0 ]; then
+    echo "FAILED bash 3.2 compatibility checks"
+    exit 1
+fi
+echo "All bash 3.2 compatibility checks passed."

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -57,8 +57,8 @@ echo
 
 # Check bash version
 echo "Bash version: $BASH_VERSION"
-if ((BASH_VERSINFO[0] < 4)); then
-    echo -e "${RED}Error: Bash 4.0+ required. Current version: $BASH_VERSION${NC}"
+if ((BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 2))); then
+    echo -e "${RED}Error: Bash 3.2+ required. Current version: $BASH_VERSION${NC}"
     exit 1
 fi
 echo -e "${GREEN}Bash version OK${NC}"

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -17,9 +17,9 @@ setup_suite() {
         exit 1
     fi
     
-    # Verify bash version (4.0+)
-    if ((BASH_VERSINFO[0] < 4)); then
-        echo "Error: Bash 4.0+ required. Current version: $BASH_VERSION"
+    # Verify bash version (3.2+)
+    if ((BASH_VERSINFO[0] < 3 || (BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 2))); then
+        echo "Error: Bash 3.2+ required. Current version: $BASH_VERSION"
         exit 1
     fi
 }

--- a/tests/test_commit_prompt.bats
+++ b/tests/test_commit_prompt.bats
@@ -69,7 +69,8 @@ teardown() {
 @test "declining split AI suggestion leaves blank line before type menu" {
     create_test_file "gitb" "changed"
     git add gitb
-    declare -gA split_groups=([gitb]="gitb")
+    gmap_clear split_groups
+    gmap_set split_groups "gitb" "gitb"
     split_group_keys=(gitb)
     current_branch="main"
     push=""
@@ -164,11 +165,10 @@ teardown() {
     git rm old.txt >/dev/null
     git add docs/new.md scripts/change.sh
 
-    declare -gA split_groups=(
-        [docs]="docs/new.md"
-        [scripts]="scripts/change.sh"
-        [misc]="old.txt"
-    )
+    gmap_clear split_groups
+    gmap_set split_groups "docs" "docs/new.md"
+    gmap_set split_groups "scripts" "scripts/change.sh"
+    gmap_set split_groups "misc" "old.txt"
     split_group_keys=(docs scripts misc)
 
     run print_split_groups_preview
@@ -202,7 +202,7 @@ teardown() {
         while IFS= read -r file; do
             [ -z "$file" ] && continue
             git add -- "$file"
-        done <<< "${split_groups[$scope]}"
+        done <<< "$(gmap_get split_groups "$scope")"
     done
 }
 
@@ -212,10 +212,9 @@ teardown() {
     create_test_file "scripts/change.sh"
     git add docs scripts
 
-    declare -gA split_groups=(
-        [docs]="docs/guide.md"
-        [scripts]="scripts/change.sh"
-    )
+    gmap_clear split_groups
+    gmap_set split_groups "docs" "docs/guide.md"
+    gmap_set split_groups "scripts" "scripts/change.sh"
     split_group_keys=(docs scripts)
     current_branch="main"
     push=""

--- a/tests/test_commit_split_deletions.bats
+++ b/tests/test_commit_split_deletions.bats
@@ -42,9 +42,9 @@ teardown() {
 
 @test "_capture_split_statuses: maps each staged file to its change type" {
     _capture_split_statuses
-    [ "${_split_status_by_file[mod/a.txt]}" = "M" ]
-    [ "${_split_status_by_file[del/b.txt]}" = "D" ]
-    [ "${_split_status_by_file[.github/d.txt]}" = "A" ]
+    [ "$(gmap_get _split_status_by_file "mod/a.txt")" = "M" ]
+    [ "$(gmap_get _split_status_by_file "del/b.txt")" = "D" ]
+    [ "$(gmap_get _split_status_by_file ".github/d.txt")" = "A" ]
 }
 
 @test "_stage_file_by_status D: re-stages the deletion via git rm --cached" {
@@ -109,7 +109,8 @@ teardown() {
     # Build a snapshot file in the new STATUS<TAB>FILE format.
     snap=$(mktemp)
     while IFS= read -r f; do
-        printf '%s\t%s\n' "${_split_status_by_file[$f]:-M}" "$f"
+        _st=$(gmap_get _split_status_by_file "$f"); [ -z "$_st" ] && _st="M"
+        printf '%s\t%s\n' "$_st" "$f"
     done < <(git diff --name-only --cached) > "$snap"
 
     # Tear staging down and ask the helper to restore it from the snapshot.

--- a/tests/test_commit_split_monorepo.bats
+++ b/tests/test_commit_split_monorepo.bats
@@ -85,8 +85,8 @@ stage() {
     build_split_groups_from_staged
     # Every bff-prefixed file lands in the bff group (or a parent that takes
     # precedence — services is filtered, so bff is the next match).
-    [ -n "${split_groups[bff]:-}" ]
-    bff_files=$(printf '%s' "${split_groups[bff]}" | grep -c '^services/bff/')
+    gmap_has split_groups "bff"
+    bff_files=$(printf '%s' "$(gmap_get split_groups "bff")" | grep -c '^services/bff/')
     [ "$bff_files" -eq 4 ]
 }
 
@@ -102,14 +102,14 @@ stage() {
     stage "services/vip-bot/rubrics/vip_signal.py"
 
     build_split_groups_from_staged
-    [ -n "${split_groups[main-bot]:-}" ]
-    [ -n "${split_groups[vip-bot]:-}" ]
-    main_count=$(printf '%s' "${split_groups[main-bot]}" | grep -c '^services/main-bot/')
-    vip_count=$(printf '%s' "${split_groups[vip-bot]}" | grep -c '^services/vip-bot/')
+    gmap_has split_groups "main-bot"
+    gmap_has split_groups "vip-bot"
+    main_count=$(printf '%s' "$(gmap_get split_groups "main-bot")" | grep -c '^services/main-bot/')
+    vip_count=$(printf '%s' "$(gmap_get split_groups "vip-bot")" | grep -c '^services/vip-bot/')
     [ "$main_count" -eq 3 ]
     [ "$vip_count" -eq 3 ]
     # And no `rubrics` scope at all.
-    [ -z "${split_groups[rubrics]:-}" ]
+    ! gmap_has split_groups "rubrics"
 }
 
 @test "monorepo: filename-shaped dirs at depth 4+ no longer beat top-level scopes" {
@@ -125,13 +125,13 @@ stage() {
 
     build_split_groups_from_staged
     # All four bff-prefixed files belong to bff, not external or handler.
-    [ -n "${split_groups[bff]:-}" ]
-    bff_files=$(printf '%s' "${split_groups[bff]}" | grep -c '^services/bff/')
+    gmap_has split_groups "bff"
+    bff_files=$(printf '%s' "$(gmap_get split_groups "bff")" | grep -c '^services/bff/')
     [ "$bff_files" -eq 4 ]
     # And no external/handler scope was created for files that have a
     # shallower match available.
-    [ -z "${split_groups[external]:-}" ]
-    [ -z "${split_groups[handler]:-}" ]
+    ! gmap_has split_groups "external"
+    ! gmap_has split_groups "handler"
 }
 
 @test "monorepo: 'scripts' is filtered; sub-tool dir or filename stem wins" {
@@ -147,12 +147,12 @@ stage() {
 
     build_split_groups_from_staged
     # `scripts` itself must not be a scope (it's filtered).
-    [ -z "${split_groups[scripts]:-}" ]
+    ! gmap_has split_groups "scripts"
     # llm_comparison takes the two sub-dir files.
-    [ -n "${split_groups[llm_comparison]:-}" ]
-    [ "$(printf '%s' "${split_groups[llm_comparison]}" | grep -c .)" -eq 2 ]
+    gmap_has split_groups "llm_comparison"
+    [ "$(printf '%s' "$(gmap_get split_groups "llm_comparison")" | grep -c .)" -eq 2 ]
     # build_release.sh becomes scope `build_release` via stem fallback.
-    [ -n "${split_groups[build_release]:-}" ]
+    gmap_has split_groups "build_release"
 }
 
 @test "stem fallback: scripts/commit.sh produces 'commit' scope" {
@@ -162,9 +162,9 @@ stage() {
     stage "tests/test_commit.bats"
 
     build_split_groups_from_staged
-    [ -z "${split_groups[scripts]:-}" ]
-    [ -n "${split_groups[commit]:-}" ]
-    [ -n "${split_groups[tests]:-}" ]
+    ! gmap_has split_groups "scripts"
+    gmap_has split_groups "commit"
+    gmap_has split_groups "tests"
 }
 
 @test "stem fallback: skipped dirs at depth 1 trigger filename stem" {
@@ -177,12 +177,12 @@ stage() {
     stage "tests/test_a.py"
 
     build_split_groups_from_staged
-    [ -z "${split_groups[lib]:-}" ]
-    [ -z "${split_groups[src]:-}" ]
-    [ -z "${split_groups[bin]:-}" ]
-    [ -n "${split_groups[auth]:-}" ]
-    [ -n "${split_groups[router]:-}" ]
-    [ -n "${split_groups[serve]:-}" ]
+    ! gmap_has split_groups "lib"
+    ! gmap_has split_groups "src"
+    ! gmap_has split_groups "bin"
+    gmap_has split_groups "auth"
+    gmap_has split_groups "router"
+    gmap_has split_groups "serve"
 }
 
 @test "stem fallback: generic stems (main, index, init) still go to misc" {
@@ -197,11 +197,11 @@ stage() {
     build_split_groups_from_staged
     # All three generic-stem files should land in misc, not as their own
     # scope (we don't want main/index/utils as commit scopes).
-    [ -z "${split_groups[main]:-}" ]
-    [ -z "${split_groups[index]:-}" ]
-    [ -z "${split_groups[utils]:-}" ]
-    [ -n "${split_groups[misc]:-}" ]
-    misc_count=$(printf '%s' "${split_groups[misc]}" | grep -c .)
+    ! gmap_has split_groups "main"
+    ! gmap_has split_groups "index"
+    ! gmap_has split_groups "utils"
+    gmap_has split_groups "misc"
+    misc_count=$(printf '%s' "$(gmap_get split_groups "misc")" | grep -c .)
     [ "$misc_count" -ge 3 ]
 }
 
@@ -215,10 +215,10 @@ stage() {
     stage "tests/test_a.py"
 
     build_split_groups_from_staged
-    [ -z "${split_groups[makefile]:-}" ]
-    [ -z "${split_groups[readme]:-}" ]
-    [ -z "${split_groups[package]:-}" ]
-    [ -n "${split_groups[misc]:-}" ]
+    ! gmap_has split_groups "makefile"
+    ! gmap_has split_groups "readme"
+    ! gmap_has split_groups "package"
+    gmap_has split_groups "misc"
 }
 
 @test "monorepo: lib/<package> still surfaces the package name as scope" {
@@ -244,7 +244,7 @@ stage() {
     # whale and help only have 1 file each; if scopes_arr cuts them out,
     # they fall back to misc. Either way they must NOT land under
     # `services` (which is filtered).
-    if [ -n "${split_groups[services]:-}" ]; then
+    if gmap_has split_groups "services"; then
         echo "services should not exist as a scope" >&2
         return 1
     fi
@@ -295,47 +295,47 @@ stage() {
 }
 
 @test "consolidate: stem-fallback explosion collapses by top-level dir" {
-    declare -gA split_groups=()
+    gmap_clear split_groups
     split_group_keys=()
     # Simulate the real repro: 6 workflow files + 6 node UI files, each
     # currently sitting in its own filename-stem scope.
     local i
     for i in 1 2 3 4 5 6; do
-        split_groups[wf$i]=".github/workflows/job$i.yml"
+        gmap_set split_groups "wf$i" ".github/workflows/job$i.yml"
         split_group_keys+=("wf$i")
     done
     for i in 1 2 3 4 5 6; do
-        split_groups[ui$i]="node/apps/user-web/src/comp$i.tsx"
+        gmap_set split_groups "ui$i" "node/apps/user-web/src/comp$i.tsx"
         split_group_keys+=("ui$i")
     done
 
     consolidate_split_groups 7
     # 12 stem scopes collapse to 2 location scopes (leading dot stripped).
     [ "${#split_group_keys[@]}" -eq 2 ]
-    [ -n "${split_groups[github]:-}" ]
-    [ -n "${split_groups[node]:-}" ]
-    [ "$(printf '%s\n' "${split_groups[github]}" | grep -c .)" -eq 6 ]
-    [ "$(printf '%s\n' "${split_groups[node]}" | grep -c .)" -eq 6 ]
+    gmap_has split_groups "github"
+    gmap_has split_groups "node"
+    [ "$(printf '%s\n' "$(gmap_get split_groups "github")" | grep -c .)" -eq 6 ]
+    [ "$(printf '%s\n' "$(gmap_get split_groups "node")" | grep -c .)" -eq 6 ]
 }
 
 @test "consolidate: stage-2 keeps largest groups and folds tail into misc" {
-    declare -gA split_groups=()
+    gmap_clear split_groups
     split_group_keys=()
     # 'a' is the biggest dir; b..i have a single file each.
-    split_groups[a]=$'a/1\na/2\na/3\na/4'
+    gmap_set split_groups "a" $'a/1\na/2\na/3\na/4'
     split_group_keys+=("a")
     local d
     for d in b c dd ee ff gg hh ii; do
-        split_groups[$d]="$d/1"
+        gmap_set split_groups "$d" "$d/1"
         split_group_keys+=("$d")
     done
 
     consolidate_split_groups 4
     [ "${#split_group_keys[@]}" -le 4 ]
     # Largest group survives intact; the long tail is bundled into misc.
-    [ -n "${split_groups[a]:-}" ]
-    [ "$(printf '%s\n' "${split_groups[a]}" | grep -c .)" -eq 4 ]
-    [ -n "${split_groups[misc]:-}" ]
+    gmap_has split_groups "a"
+    [ "$(printf '%s\n' "$(gmap_get split_groups "a")" | grep -c .)" -eq 4 ]
+    gmap_has split_groups "misc"
 }
 
 # --- Scope-name normalization (no leading/trailing . _ - in scopes) --------
@@ -361,8 +361,8 @@ stage() {
     [[ "$detected_scopes" != *".superpowers"* ]]
 
     build_split_groups_from_staged
-    [ -n "${split_groups[superpowers]:-}" ]
-    [ -z "${split_groups[.superpowers]:-}" ]
+    gmap_has split_groups "superpowers"
+    ! gmap_has split_groups ".superpowers"
 }
 
 @test "normalize: underscore-prefixed filename stem drops the underscore" {
@@ -371,22 +371,22 @@ stage() {
     stage "tests/test_a.py"   # second scope
 
     build_split_groups_from_staged
-    [ -n "${split_groups[deploy-production]:-}" ]
-    [ -n "${split_groups[build-services]:-}" ]
-    [ -z "${split_groups[_deploy-production]:-}" ]
-    [ -z "${split_groups[_build-services]:-}" ]
+    gmap_has split_groups "deploy-production"
+    gmap_has split_groups "build-services"
+    ! gmap_has split_groups "_deploy-production"
+    ! gmap_has split_groups "_build-services"
 }
 
 @test "consolidate: no-op when group count is within the cap" {
-    declare -gA split_groups=()
+    gmap_clear split_groups
     split_group_keys=()
-    split_groups[bff]="services/bff/main.go"
+    gmap_set split_groups "bff" "services/bff/main.go"
     split_group_keys+=("bff")
-    split_groups[api]="services/api/main.go"
+    gmap_set split_groups "api" "services/api/main.go"
     split_group_keys+=("api")
 
     consolidate_split_groups 7
     [ "${#split_group_keys[@]}" -eq 2 ]
-    [ -n "${split_groups[bff]:-}" ]
-    [ -n "${split_groups[api]:-}" ]
+    gmap_has split_groups "bff"
+    gmap_has split_groups "api"
 }

--- a/tests/test_keyboard_input.bats
+++ b/tests/test_keyboard_input.bats
@@ -65,16 +65,17 @@ setup() {
 }
 
 @test "normalize_key: maps all Russian alphabet keys" {
-    # Spot-check a representative subset of mappings (lowercase)
-    declare -A expected=(
-        [ц]=w [у]=e [к]=r [е]=t [г]=u [ш]=i [щ]=o [з]=p
-        [ы]=s [в]=d [а]=f [п]=g [р]=h [о]=j [л]=k [д]=l
-        [я]=z [ч]=x [с]=c [м]=v [и]=b [ь]=m
-    )
-    for ru in "${!expected[@]}"; do
+    # Spot-check a representative subset of mappings (lowercase). Pairs are
+    # "<ru> <latin>" walked two at a time — no associative array, so the test
+    # itself stays bash 3.2 compatible.
+    local pairs="ц w у e к r е t г u ш i щ o з p ы s в d а f п g р h о j л k д l я z ч x с c м v и b ь m"
+    set -- $pairs
+    while [ "$#" -ge 2 ]; do
+        local ru="$1" latin="$2"
+        shift 2
         normalize_key "$ru"
-        [ "$normalized_key" = "${expected[$ru]}" ] || \
-            { echo "Failed: '$ru' -> '$normalized_key', expected '${expected[$ru]}'"; return 1; }
+        [ "$normalized_key" = "$latin" ] || \
+            { echo "Failed: '$ru' -> '$normalized_key', expected '$latin'"; return 1; }
     done
 }
 

--- a/tests/test_keyboard_input.bats
+++ b/tests/test_keyboard_input.bats
@@ -216,6 +216,14 @@ setup() {
 }
 
 @test "read_editable_input: Esc submits empty input" {
+    # read_editable_input uses readline (`read -e`) and a `bind` macro to make a
+    # lone Esc clear-and-submit. bash 3.2 ships readline 5.x, which has no
+    # keyseq-timeout, so a lone Esc is treated as an escape-sequence prefix and
+    # the macro never fires (the prompt waits for more bytes). The Esc nicety is
+    # therefore a bash 4+ feature; skip the check on 3.2.
+    if ((BASH_VERSINFO[0] < 4)); then
+        skip "lone-Esc readline binding requires bash 4+ (keyseq-timeout)"
+    fi
     run python3 - <<'PY'
 import os
 import pty

--- a/tests/test_keyboard_input.bats
+++ b/tests/test_keyboard_input.bats
@@ -100,11 +100,11 @@ setup() {
     is_yes ""
 }
 
-@test "is_yes: accepts Russian н (Y position lowercase)" {
+@test "is_yes: accepts Russian-layout Y key, lowercase" {
     is_yes "н"
 }
 
-@test "is_yes: accepts Russian Н (Y position uppercase)" {
+@test "is_yes: accepts Russian-layout Y key, uppercase" {
     is_yes "Н"
 }
 
@@ -131,11 +131,11 @@ setup() {
     is_no "N"
 }
 
-@test "is_no: accepts Russian т (N position lowercase)" {
+@test "is_no: accepts Russian-layout N key, lowercase" {
     is_no "т"
 }
 
-@test "is_no: accepts Russian Т (N position uppercase)" {
+@test "is_no: accepts Russian-layout N key, uppercase" {
     is_no "Т"
 }
 
@@ -178,7 +178,7 @@ setup() {
     [ "$sanitized_choice" = "=" ]
 }
 
-@test "sanitize_choice_input: accepts Russian н as y" {
+@test "sanitize_choice_input: accepts Russian-layout Y key as y" {
     sanitize_choice_input "н"
     [ "$sanitized_choice" = "y" ]
 }

--- a/tests/test_portable_deleted_cleanup.bats
+++ b/tests/test_portable_deleted_cleanup.bats
@@ -27,9 +27,11 @@ teardown() {
     cleanup_test_repo
 }
 
-# Run the portable cleanup snippet — copied verbatim from merge.sh / rebase.sh.
+# Run the portable cleanup snippet — copied verbatim from merge.sh / rebase.sh
+# (read-loop instead of bash 4's mapfile, so the snippet runs on bash 3.2).
 run_portable_cleanup() {
-    mapfile -t _deleted < <(git ls-files --deleted)
+    _deleted=()
+    while IFS= read -r _df; do [ -n "$_df" ] && _deleted+=("$_df"); done < <(git ls-files --deleted)
     [ ${#_deleted[@]} -gt 0 ] && git rm -- "${_deleted[@]}" 2>/dev/null
     return 0
 }
@@ -58,7 +60,7 @@ run_portable_cleanup() {
     [ -z "$(git status --porcelain c)" ]
 }
 
-@test "portable: filenames with spaces survive mapfile word boundaries" {
+@test "portable: filenames with spaces survive read-loop word boundaries" {
     : > "with space.txt"
     git add "with space.txt"
     git commit -q -m "add spaced"


### PR DESCRIPTION
## Summary

macOS ships **bash 3.2** as `/bin/bash`, but gitbasher required **bash 4.0+** and re-exec'd to a Homebrew bash (or printed an upgrade hint) when it couldn't find one. This PR removes every bash 4-only feature so gitbasher runs **natively on bash 3.2** — no `brew install bash` needed.

### Was it possible? Yes — the bash-4 surface was small and bounded

A full scan of all 29 scripts found only four bash-4-only constructs in use:

| Feature | Count | How it was replaced |
|---|---|---|
| Associative arrays (`declare -A`/`local -A`) | 17 | shim for string keys; indexed arrays for integer keys |
| `mapfile -t` | 4 | `while IFS= read -r` loops |
| `${var,,}` / `${var^^}` case-folding | 7 | `to_lower` / `to_upper` (tr-based) |
| `read -i` (preloaded readline) | 1 | kept on bash 4+, graceful 3.2 fallback |

No `&>>`, `coproc`, `globstar`, negative array indices, `${var@Q}`, `printf %()T`, or `wait -n` were used.

## Core changes

**Portable map/set shim** (`scripts/common.sh`): `gmap_set/get/has/inc/keys/size/clear` + `gset_add/has`. Keys are hex-encoded into variable-name suffixes (byte-exact, locale-independent, collision-free); values are stored verbatim via `printf -v` — **never `eval`** — so arbitrary value content (newlines, quotes, `$(...)`) is stored as inert data. Insertion order is preserved. Plus `to_lower`/`to_upper`.

**All 17 associative-array sites converted:**
- String-keyed → shim: `commit.sh` `split_groups`, `_split_status_by_file`, scope counters/depths, AI-grouping sets, `staged_status_by_file`; `squash.sh` expected/seen hash sets.
- Integer-keyed → plain indexed arrays: commit-type menu, config separators, squash per-group accumulators, branch/worktree prefix pickers (the prefix-dedup sets became `sort -u`).

**`read -i`**: bash 4+ still gets in-place editing of pre-filled prompts (editing an AI commit message, renaming a branch). On bash 3.2 the prompt shows the current value and keeps it on an empty submit.

**Version gate lowered to 3.2** in `gitb.sh`, `install.sh`, `run_tests.sh`, `setup_suite.bash`. The re-exec-to-newer-bash safety net now only triggers for genuinely ancient bash `< 3.2`.

## Tests, CI & docs

- Updated the split-commit tests' internal-structure assertions to use the shim accessors instead of direct `${split_groups[...]}` access.
- **New `bash32` CI job** runs the entire bats suite under macOS's real `/bin/bash` 3.2 (forcing every `#!/usr/bin/env bash` to resolve to 3.2 via a PATH symlink) — the genuine compatibility gate, since the existing macOS job prepends Homebrew's bash 5.
- Updated README, FAQ, ARCHITECTURE, CONTRIBUTING, the PR template, and the marketing site copy to state bash 3.2+.

## Verification

- **Full bats suite: 614 pass / 18 fail — byte-identical to the pre-change baseline** (the 18 are pre-existing, environment-related: git output formatting in list_branches / push / commit_list / ref_list / worktree-list). **Zero new failures.**
- `shellcheck --severity=error` clean across all scripts (matches CI).
- Shim unit-tested under bash 5 with tricky inputs: paths with slashes/dots, values with newlines and shell metacharacters, byte-prefix keys, UTF-8/emoji/tab keys, and map-name prefix-collision cases.

> Note: the sandbox's network policy blocked downloading bash 3.2 source (403 on gnu.org mirrors), so local validation against a real 3.2 binary wasn't possible — the new `bash32` CI job covers that on every PR. All constructs used are documented bash 3.2 features (`printf -v`, array `+=`, `[[ =~ ]]`, C-style `for`, process substitution, `local LC_ALL=C`).

https://claude.ai/code/session_01Qe2ozqMK6g44TagtEY8Q9E

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qe2ozqMK6g44TagtEY8Q9E)_