### PR TITLE
fix(commit): strip model reasoning preamble from AI commit messages

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -96,6 +96,35 @@ function is_redundant_scope {
     return 1
 }
 
+### Drop any reasoning preamble a model emits before the actual commit
+### message. Some providers/models ignore the "output ONLY the commit
+### message" instruction and prepend an analysis ("Looking at the staged
+### files I can identify the following changes: 1. ... feat(x): ...");
+### without this, the whole analysis becomes the commit subject and the real
+### `type(scope): subject` header is buried in the body. We locate the first
+### line that is a Conventional Commit header (lowercase type, optional scope,
+### optional breaking-change `!`) and discard everything before it, keeping the
+### header plus any following body. If no header is found we return the input
+### unchanged so non-conventional output is left for the caller to handle.
+### LC_ALL=C avoids "illegal byte sequence" errors from BSD awk/sed on
+### non-ASCII AI responses.
+function strip_ai_reasoning_preamble {
+    local input="$1"
+    local stripped
+    # Drop standalone markdown fence lines, then keep from the first
+    # Conventional Commit header onward.
+    stripped=$(printf '%s' "$input" | LC_ALL=C awk '
+        /^[[:space:]]*```[a-zA-Z]*[[:space:]]*$/ { next }
+        found { print; next }
+        /^[[:space:]]*(feat|fix|docs|style|refactor|test|chore|perf|ci|build|revert)(\([^)]+\))?!?:[[:space:]].+/ { found=1; print }
+    ')
+    if [ -n "$stripped" ]; then
+        printf '%s' "$stripped"
+    else
+        printf '%s' "$input"
+    fi
+}
+
 ### Trim quoting/whitespace and drop a redundant scope from an AI-generated
 ### commit message. Use this at every site that captures AI output so a new
 ### call site can't forget the strip step (the bug that produced
@@ -104,7 +133,8 @@ function is_redundant_scope {
 ### response contains non-ASCII characters.
 function clean_ai_commit_message {
     local cleaned
-    cleaned=$(echo "$1" | LC_ALL=C sed 's/^"//;s/"$//' | LC_ALL=C sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+    cleaned=$(strip_ai_reasoning_preamble "$1")
+    cleaned=$(echo "$cleaned" | LC_ALL=C sed 's/^"//;s/"$//' | LC_ALL=C sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
     strip_redundant_scope "$cleaned"
 }
 

--- a/tests/test_redundant_scope.bats
+++ b/tests/test_redundant_scope.bats
@@ -193,3 +193,40 @@ setup() {
     result=$(clean_ai_commit_message "feat(auth): add login")
     [ "$result" = "feat(auth): add login" ]
 }
+
+# ===== strip_ai_reasoning_preamble: drop chatty model output =====
+
+@test "strip_ai_reasoning_preamble: drops analysis preamble before header" {
+    input=$'Looking at the staged files and diff, I can identify the following distinct changes:\n\n1. **New network abstraction layer**: Added network/provider.go\n2. **New bufconn test utilities**: Added bufconn.go\n\nThis is a cohesive feature. The dominant type is `feat`.\n\nfeat(network): add provider abstraction and bufconn test utilities for in-memory networking'
+    result=$(strip_ai_reasoning_preamble "$input")
+    [ "$result" = "feat(network): add provider abstraction and bufconn test utilities for in-memory networking" ]
+}
+
+@test "strip_ai_reasoning_preamble: keeps body after the extracted header" {
+    input=$'Here is the commit message:\n\nfix(api): treat null user as not found\n\nThe upstream service started returning null for deleted users.'
+    expected=$'fix(api): treat null user as not found\n\nThe upstream service started returning null for deleted users.'
+    result=$(strip_ai_reasoning_preamble "$input")
+    [ "$result" = "$expected" ]
+}
+
+@test "strip_ai_reasoning_preamble: strips surrounding markdown fences" {
+    input=$'```\nfeat(auth): add login\n```'
+    result=$(strip_ai_reasoning_preamble "$input")
+    [ "$result" = "feat(auth): add login" ]
+}
+
+@test "strip_ai_reasoning_preamble: leaves clean header untouched" {
+    result=$(strip_ai_reasoning_preamble "feat(auth): add login")
+    [ "$result" = "feat(auth): add login" ]
+}
+
+@test "strip_ai_reasoning_preamble: returns input unchanged when no header found" {
+    result=$(strip_ai_reasoning_preamble "just some prose with no conventional header")
+    [ "$result" = "just some prose with no conventional header" ]
+}
+
+@test "clean_ai_commit_message: extracts header from chatty multi-line output" {
+    input=$'Looking at the staged files and diff, I can identify the following distinct changes:\n\n1. New network abstraction layer\n\nfeat(network): add provider abstraction and bufconn test utilities for in-memory networking'
+    result=$(clean_ai_commit_message "$input")
+    [ "$result" = "feat(network): add provider abstraction and bufconn test utilities for in-memory networking" ]
+}


### PR DESCRIPTION
## Problem

Some AI providers/models ignore the "output ONLY the commit message" instruction and prepend a reasoning analysis before the actual message. When that happened, gitbasher used the **whole analysis** as the commit, so the subject became:

> Looking at the staged files and diff, I can identify the following distinct changes:

…and the real `feat(network): add provider abstraction…` header was buried at the bottom of the body. (Reported via a screenshot of exactly this commit.)

`clean_ai_commit_message` only trimmed quotes/whitespace and dropped redundant scopes — it had no defense against chatty model output.

## Fix

Added `strip_ai_reasoning_preamble`, wired into `clean_ai_commit_message` (so every AI capture site benefits). It:

- drops standalone markdown fence lines, and
- keeps everything from the **first Conventional Commit header line** onward (lowercase `type`, optional `(scope)`, optional breaking-change `!`), discarding any preceding prose.

The header's body (in `full` mode) is preserved. If no conventional header is found, the input is returned unchanged so non-conventional output is left for the caller to handle, matching existing behavior.

## Tests

Added 6 regression tests to `tests/test_redundant_scope.bats`, including the exact multi-line analysis-preamble case from the screenshot. Full file: **33/33 passing**.

https://claude.ai/code/session_016AUVr5TeFN4XwmWwXdhJgS

---
_Generated by [Claude Code](https://claude.ai/code/session_016AUVr5TeFN4XwmWwXdhJgS)_