### PR TITLE
feat(commit): order split commits by scope dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,9 @@ gitb origin remove                               # delete the remote
 | `gitbasher.ai-model[-task]` | `gitb cfg model` | AI model overrides (per provider) |
 | `gitbasher.proxy` | `gitb cfg proxy` | HTTP proxy for AI calls |
 | `gitbasher.worktreebase` | `git config gitbasher.worktreebase <dir>` | Parent directory for new worktrees (defaults to `..`) |
+| `gitbasher.commit-auto-split` | `git config gitbasher.commit-auto-split <ask\|always\|never>` | Offer to split a commit per scope (default `ask`) |
+| `gitbasher.commit-max-split-groups` | `git config gitbasher.commit-max-split-groups <2..20>` | Cap on split commits per run (default `7`) |
+| `gitbasher.commit-split-order` | `git config gitbasher.commit-split-order <auto\|alpha>` | Order split commits by dependency (`auto`, default) or alphabetically (`alpha`) |
 
 **Clear gitbasher config** (per-repo settings live with the repo and disappear with it):
 ```bash

--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -415,6 +415,85 @@ function get_max_split_groups {
     printf '%s' "$v"
 }
 
+### Reorder split_group_keys so foundational scopes commit first.
+#
+# Git hands files back alphabetically by path, so the split commits would
+# otherwise run in alphabetical order — which often inverts the real
+# dependency order. In the motivating case `network/` defines the types that
+# `grpcconn/`, `grpcsrv/` and `httpsrv/` all consume, yet `network` sorts last
+# and lands in the final commit, leaving every earlier commit referencing code
+# that doesn't exist yet in history.
+#
+# Heuristic: a scope that OTHER scopes reference is probably a dependency, so
+# it should be committed first. For each scope S we count how many *sibling*
+# groups mention S's name as a whole word in their staged additions (e.g.
+# `network.GRPCOptions`, `import ".../network"`). Scopes referenced by more
+# siblings sort earlier. The `misc` grab-bag always sinks last, and ties keep
+# the original (alphabetical) order so the result stays deterministic. When no
+# cross-references exist the order is unchanged.
+#
+# Controlled by gitbasher.commit-split-order:
+#   auto  (default) - apply this dependency heuristic
+#   alpha           - keep git's alphabetical-by-path order (legacy behaviour)
+#
+# Operates in place on split_group_keys. Safe to call with the index already
+# staged; it only reads diffs.
+function order_split_groups_by_dependency {
+    local mode
+    mode=$(get_config_value gitbasher.commit-split-order "auto")
+    [ "$mode" = "alpha" ] && return 0
+    [ ${#split_group_keys[@]} -lt 2 ] && return 0
+
+    # Precompute each group's staged additions once (added lines only, minus
+    # the +++ file header). Used as the haystack for whole-word name matches.
+    local -A added_text=()
+    local scope f
+    local -a farr
+    for scope in "${split_group_keys[@]}"; do
+        farr=()
+        while IFS= read -r f; do [ -n "$f" ] && farr+=("$f"); done <<< "${split_groups[$scope]}"
+        [ ${#farr[@]} -eq 0 ] && { added_text[$scope]=""; continue; }
+        added_text[$scope]=$(git -c core.quotePath=false diff --cached -- "${farr[@]}" 2>/dev/null \
+            | grep '^+' | grep -v '^+++' || true)
+    done
+
+    # dep_score[S] = number of OTHER groups that reference S by name.
+    local -A dep_score=()
+    local s o
+    for s in "${split_group_keys[@]}"; do
+        dep_score[$s]=0
+        [ "$s" = "misc" ] && continue
+        for o in "${split_group_keys[@]}"; do
+            [ "$o" = "$s" ] && continue
+            # -F: scope names can contain regex-special chars (dots, dashes).
+            # -w: match the whole token so `net` doesn't match `network`.
+            if printf '%s' "${added_text[$o]}" | grep -qwF -- "$s"; then
+                dep_score[$s]=$(( ${dep_score[$s]} + 1 ))
+            fi
+        done
+    done
+
+    # Stable sort: score descending, original index ascending. `misc` is
+    # forced below every real scope so the catch-all never leads.
+    local -a decorated=()
+    local i=0 key sc
+    for key in "${split_group_keys[@]}"; do
+        sc="${dep_score[$key]}"
+        [ "$key" = "misc" ] && sc=-1
+        decorated+=("$(printf '%d\t%05d\t%s' "$sc" "$i" "$key")")
+        i=$((i + 1))
+    done
+    local entry
+    IFS=$'\n' decorated=($(printf '%s\n' "${decorated[@]}" | sort -t$'\t' -k1,1nr -k2,2n))
+    unset IFS
+
+    local -a reordered=()
+    for entry in "${decorated[@]}"; do
+        reordered+=("${entry##*$'\t'}")
+    done
+    split_group_keys=("${reordered[@]}")
+}
+
 ### Cap the number of split groups so a large changeset stays reviewable.
 # When the grouping exceeds the cap, collapse it in two stages:
 #   1. Re-bucket every file by its first meaningful (non-generic) path
@@ -1181,6 +1260,9 @@ function perform_commit_split {
 # The number of groups is capped at gitbasher.commit-max-split-groups (default
 # 7) so a huge changeset stays a handful of reviewable commits instead of
 # dozens of micro-commits — see consolidate_split_groups.
+# The resulting commits are ordered so foundational scopes (those other scopes
+# reference) commit first — see order_split_groups_by_dependency. Disable with
+# gitbasher.commit-split-order = "alpha".
 # Returns to the caller (no exit) when the user declines or the split isn't
 # applicable; perform_commit_split exits the script directly on success.
 # $1: "true" to force the split flow even when the config says "ask"/"never"
@@ -1239,6 +1321,10 @@ function try_offer_commit_split {
         fi
         return 1
     fi
+
+    # Commit foundational scopes (those other scopes reference) first, so the
+    # split commits don't reference code that history hasn't introduced yet.
+    order_split_groups_by_dependency
 
     echo
     print_split_groups_preview

--- a/tests/test_commit_split_order.bats
+++ b/tests/test_commit_split_order.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+
+# Tests for dependency-aware ordering of split commits.
+#
+# Git returns staged files alphabetically by path, so without reordering the
+# split commits run in alphabetical order. When a shared/foundational scope
+# (e.g. `network/`, which defines the types every other scope consumes) sorts
+# last, the earlier commits reference code that history hasn't introduced yet.
+#
+# order_split_groups_by_dependency reorders split_group_keys so a scope that
+# OTHER scopes reference by name commits first. Controlled by
+# gitbasher.commit-split-order (auto = on, alpha = legacy order).
+
+load setup_suite
+
+setup() {
+    setup_test_repo
+    GITBASHER_SKIP_INIT_QUERIES=1 source "${GITBASHER_ROOT}/scripts/init.sh"
+    source "${GITBASHER_ROOT}/scripts/common.sh"
+    source "${GITBASHER_ROOT}/scripts/commit.sh"
+    cd "$TEST_REPO"
+}
+
+teardown() {
+    cleanup_test_repo
+}
+
+# Stage a file with real content so the staged diff carries added lines the
+# heuristic can scan for cross-scope references.
+stage_content() {
+    local path="$1"; shift
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$@" > "$path"
+    git add "$path"
+}
+
+# Build the foundational `network` scope plus three dependents that each
+# reference it. `network` itself references no sibling.
+stage_network_changeset() {
+    stage_content "network/provider.go" \
+        "package network" \
+        "type GRPCOptions struct{}" \
+        "type NetworkProvider struct{}"
+    stage_content "grpcconn/options.go" \
+        "package grpcconn" \
+        'import "example.com/proj/network"' \
+        "var _ = network.GRPCOptions{}"
+    stage_content "grpcsrv/grpcsrv.go" \
+        "package grpcsrv" \
+        'import "example.com/proj/network"' \
+        "var _ = network.NetworkProvider{}"
+    stage_content "httpsrv/httpsrv.go" \
+        "package httpsrv" \
+        'import "example.com/proj/network"' \
+        "var _ = network.GRPCOptions{}"
+}
+
+@test "split order: foundational scope (network) commits first" {
+    stage_network_changeset
+
+    build_split_groups_from_staged
+    # Sanity: git hands these back alphabetically, so network starts last.
+    [ "${split_group_keys[0]}" = "grpcconn" ]
+    [ "${split_group_keys[3]}" = "network" ]
+
+    order_split_groups_by_dependency
+    # network is referenced by the three sibling scopes, so it leads now.
+    [ "${split_group_keys[0]}" = "network" ]
+}
+
+@test "split order: dependents keep their alphabetical order after the dependency" {
+    stage_network_changeset
+
+    build_split_groups_from_staged
+    order_split_groups_by_dependency
+
+    [ "${split_group_keys[0]}" = "network" ]
+    # The three count-0 dependents keep the original (alphabetical) order.
+    [ "${split_group_keys[1]}" = "grpcconn" ]
+    [ "${split_group_keys[2]}" = "grpcsrv" ]
+    [ "${split_group_keys[3]}" = "httpsrv" ]
+}
+
+@test "split order: commit-split-order=alpha keeps git's alphabetical order" {
+    git config gitbasher.commit-split-order alpha
+    stage_network_changeset
+
+    build_split_groups_from_staged
+    order_split_groups_by_dependency
+
+    # Legacy behaviour: untouched, so network stays last.
+    [ "${split_group_keys[0]}" = "grpcconn" ]
+    [ "${split_group_keys[3]}" = "network" ]
+}
+
+@test "split order: no cross-references leaves the order unchanged" {
+    # Three unrelated scopes that don't mention each other.
+    stage_content "alpha/a.go" "package alpha" "var A = 1"
+    stage_content "beta/b.go"  "package beta"  "var B = 2"
+    stage_content "gamma/c.go" "package gamma" "var C = 3"
+
+    build_split_groups_from_staged
+    order_split_groups_by_dependency
+
+    # Stable: identical scores preserve the alphabetical input order.
+    [ "${split_group_keys[0]}" = "alpha" ]
+    [ "${split_group_keys[1]}" = "beta" ]
+    [ "${split_group_keys[2]}" = "gamma" ]
+}
+
+@test "split order: whole-word match avoids false positives (net vs network)" {
+    # `netutil` mentions the bare word `network` -> it depends on network.
+    # `network` mentions `netutil` only as a substring inside `netutilizer`,
+    # which must NOT count as a reference (whole-word matching).
+    stage_content "network/provider.go" \
+        "package network" \
+        "type netutilizer struct{}"
+    stage_content "netutil/util.go" \
+        "package netutil" \
+        "var _ = network.Provider{}"
+
+    build_split_groups_from_staged
+    order_split_groups_by_dependency
+
+    # network is referenced as a whole word; netutil is not -> network leads.
+    [ "${split_group_keys[0]}" = "network" ]
+    [ "${split_group_keys[1]}" = "netutil" ]
+}
+
+@test "split order: misc grab-bag never leads" {
+    # Root-level file with no scope -> misc. A real dependency scope should
+    # still come first even though misc may sort earlier alphabetically.
+    stage_content "README.md" "# docs" "see network for details"
+    stage_content "network/provider.go" "package network" "type T struct{}"
+    stage_content "client/client.go" \
+        "package client" \
+        "var _ = network.T{}"
+
+    build_split_groups_from_staged
+    order_split_groups_by_dependency
+
+    # network leads (referenced by client); misc is forced last.
+    [ "${split_group_keys[0]}" = "network" ]
+    last_idx=$(( ${#split_group_keys[@]} - 1 ))
+    [ "${split_group_keys[$last_idx]}" = "misc" ]
+}


### PR DESCRIPTION
## Problem

Git returns staged files alphabetically by path, so atomic split commits ran in **alphabetical order**. When a foundational scope sorts last, every earlier commit references code that history hasn't introduced yet.

Concretely, in a run like:

```
Detected changes across 4 scopes:
  grpcconn  · grpcsrv · httpsrv · network (4 files)
```

`network/` defines the types (`network.GRPCOptions`, `NetworkProvider`) that `grpcconn`, `grpcsrv` and `httpsrv` all consume — yet it sorts **last** and lands in the final commit, so the first three commits won't build on their own.

## Solution

New `order_split_groups_by_dependency` reorders `split_group_keys` before the preview/commit loop:

- For each scope **S**, count how many *sibling* groups reference **S**'s name as a **whole word** in their staged additions (e.g. `network.GRPCOptions`, `import ".../network"`).
- Scopes referenced by more siblings commit **first** (they're the dependency).
- The `misc` grab-bag always sinks last.
- Ties keep the original (alphabetical) order, so the result is **deterministic** and **unchanged** when no cross-references exist.

Whole-word fixed-string matching (`grep -wF`) avoids false positives like `net` matching `network`, and tolerates regex-special chars in scope names (`main-bot`, `.github`).

### Configuration

| Key | Values | Behaviour |
|-----|--------|-----------|
| `gitbasher.commit-split-order` | `auto` (default) | Apply the dependency heuristic |
| | `alpha` | Keep git's legacy alphabetical-by-path order |

## How to also commit *without* splitting

(Answering the second half of the original question — no change needed, already supported.)

- Per-command: `gitb commit no-split` (`nsp`, `nsl`)
- Answer `N` at the `Split into N atomic commits? (y/N)` prompt (default)
- Globally: `git config gitbasher.commit-auto-split never`

## Tests

New `tests/test_commit_split_order.bats` (6 tests): foundational-scope-first, stable dependent ordering, `alpha` opt-out, no-cross-reference no-op, whole-word false-positive guard, and `misc`-never-leads. All existing split tests (36) still pass; bundle builds clean.

https://claude.ai/code/session_01VmF2WMD4pCPNE8gHN3aCty

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmF2WMD4pCPNE8gHN3aCty)_