### PR TITLE
fix(commit): treat Enter as No at atomic-split (y/N) prompt

### DIFF
--- a/scripts/commit.sh
+++ b/scripts/commit.sh
@@ -1252,7 +1252,9 @@ function try_offer_commit_split {
         echo
     fi
 
-    if ! is_yes "$choice"; then
+    # The prompt defaults to No (y/N), so Enter/empty input must decline. is_yes
+    # treats Enter as "yes" (for (Y/n) prompts), so guard against empty here.
+    if [ -z "$choice" ] || ! is_yes "$choice"; then
         return 1
     fi
 

--- a/tests/test_commit_prompt.bats
+++ b/tests/test_commit_prompt.bats
@@ -152,6 +152,51 @@ teardown() {
     [[ "$modifiers_section" == *"scope"* ]]
 }
 
+@test "split offer defaults to No when Enter is pressed at the (y/N) prompt" {
+    mkdir -p docs scripts
+    create_test_file "docs/new.md" "doc"
+    create_test_file "scripts/change.sh" "script"
+    git add docs/new.md scripts/change.sh
+
+    git config gitbasher.commit-auto-split "ask"
+    git config gitbasher.commit-ai-grouping "never"
+    llm=""
+
+    # perform_commit_split exits the script on success; stub it so we can detect
+    # whether Enter (the default-No answer) wrongly triggered a split.
+    perform_commit_split() {
+        echo "split-performed"
+        return 0
+    }
+
+    # Empty input == Enter pressed at the prompt.
+    run try_offer_commit_split "" "" <<< ""
+
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"split-performed"* ]]
+}
+
+@test "split offer proceeds when y is pressed at the (y/N) prompt" {
+    mkdir -p docs scripts
+    create_test_file "docs/new.md" "doc"
+    create_test_file "scripts/change.sh" "script"
+    git add docs/new.md scripts/change.sh
+
+    git config gitbasher.commit-auto-split "ask"
+    git config gitbasher.commit-ai-grouping "never"
+    llm=""
+
+    perform_commit_split() {
+        echo "split-performed"
+        return 0
+    }
+
+    run try_offer_commit_split "" "" <<< "y"
+
+    assert_success
+    [[ "$output" == *"split-performed"* ]]
+}
+
 @test "split group preview colors scopes and files by staged status" {
     mkdir -p docs scripts
     create_test_file "scripts/change.sh" "old"


### PR DESCRIPTION
## Problem

The atomic-split offer prompt is rendered as:

```
Split into 3 atomic commits for a cleaner changelog? (y/N)
```

The `(y/N)` capitalization signals that **No** is the default — pressing Enter should decline the split. But the answer was evaluated with `is_yes`, which intentionally treats Enter/empty input as **yes** (this is correct behavior for `(Y/n)` prompts elsewhere). As a result, pressing Enter at this prompt wrongly **applied** the split instead of skipping it.

## Fix

Guard the call site in `try_offer_commit_split` so empty input (Enter) declines:

```bash
if [ -z "$choice" ] || ! is_yes "$choice"; then
    return 1
fi
```

- Pressing **Enter** → declines (matches the `(y/N)` default).
- Pressing **y** → proceeds with the split (unchanged).
- Forced/auto-accept paths set `choice="y"` explicitly, so they are unaffected.

`is_yes` itself is left untouched since other `(Y/n)` prompts rely on its Enter-means-yes behavior. The other `(y/N)` prompts in the codebase already use `case` statements that correctly default to No.

## Tests

Added two regression tests in `tests/test_commit_prompt.bats`:

- **Enter defaults to No** — verifies `perform_commit_split` is not invoked when Enter is pressed (this test fails without the fix).
- **y proceeds** — verifies an explicit `y` still triggers the split.

All 13 tests in the suite pass.

https://claude.ai/code/session_01Je3kJoWwT99cQWTFNrbKfe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Je3kJoWwT99cQWTFNrbKfe)_