### PR TITLE
fix(merge): reconcile divergent branches in pre-merge/rebase pull

### DIFF
--- a/scripts/merge.sh
+++ b/scripts/merge.sh
@@ -77,27 +77,11 @@ function merge_script {
             read -n 1 -s choice
             if is_yes "$choice"; then
                 echo
-                echo -e "${YELLOW}Pulling ${origin_name}/${current_branch}...${ENDCOLOR}"
-                
-                pull_output=$(git pull $origin_name $current_branch 2>&1)
-                pull_code=$?
-                
-                if [ $pull_code -eq 0 ]; then
-                    echo -e "${GREEN}✓ Pulled ${origin_name}/${current_branch}${ENDCOLOR}"
-                    if [[ $pull_output == *"file changed"* ]] || [[ $pull_output == *"files changed"* ]]; then
-                        # Extract only the file statistics (lines starting with space and containing |)
-                        # and the summary line (contains "file changed" or "files changed")
-                        changes=$(echo "$pull_output" | grep -E "^ .+\|.+|[0-9]+ files? changed")
-                        if [ -n "$changes" ]; then
-                            echo
-                            print_changes_stat "$changes"
-                        fi
-                    fi
-                else
-                    echo -e "${RED}✗ Cannot pull current branch.${ENDCOLOR}"
-                    echo "$pull_output"
-                    exit $pull_code
-                fi
+                ### Reuse the canonical pull flow: fast-forward when possible,
+                ### otherwise prompt to merge or rebase divergent branches.
+                ### A bare "git pull" aborts on divergence ("Need to specify how
+                ### to reconcile divergent branches") because no strategy is set.
+                pull $current_branch $origin_name $editor
             fi
         else
             echo -e "${GREEN}✓ Current branch is up to date with remote${ENDCOLOR}"

--- a/scripts/rebase.sh
+++ b/scripts/rebase.sh
@@ -86,27 +86,11 @@ function rebase_script {
             read -n 1 -s choice
             if is_yes "$choice"; then
                 echo
-                echo -e "${YELLOW}Pulling ${origin_name}/${current_branch}...${ENDCOLOR}"
-                
-                pull_output=$(git pull $origin_name $current_branch 2>&1)
-                pull_code=$?
-                
-                if [ $pull_code -eq 0 ]; then
-                    echo -e "${GREEN}✓ Pulled ${origin_name}/${current_branch}${ENDCOLOR}"
-                    if [[ $pull_output == *"file changed"* ]] || [[ $pull_output == *"files changed"* ]]; then
-                        # Extract only the file statistics (lines starting with space and containing |)
-                        # and the summary line (contains "file changed" or "files changed")
-                        changes=$(echo "$pull_output" | grep -E "^ .+\|.+|[0-9]+ files? changed")
-                        if [ -n "$changes" ]; then
-                            echo
-                            print_changes_stat "$changes"
-                        fi
-                    fi
-                else
-                    echo -e "${RED}✗ Cannot pull current branch.${ENDCOLOR}"
-                    echo "$pull_output"
-                    exit $pull_code
-                fi
+                ### Reuse the canonical pull flow: fast-forward when possible,
+                ### otherwise prompt to merge or rebase divergent branches.
+                ### A bare "git pull" aborts on divergence ("Need to specify how
+                ### to reconcile divergent branches") because no strategy is set.
+                pull $current_branch $origin_name $editor
             fi
         else
             echo -e "${GREEN}✓ Current branch is up to date with remote${ENDCOLOR}"


### PR DESCRIPTION
## Why

`gitb merge m` (screenshot below) failed with:

```
✗ Cannot pull current branch.
...
fatal: Need to specify how to reconcile divergent branches.
```

When `gitb merge` and `gitb rebase` detect remote changes on the current branch, they offer to pull first. The pre-pull was a bare:

```bash
git pull $origin_name $current_branch
```

With **divergent** local/remote history and no `pull.rebase` / `pull.ff` configured, Git 2.27+ refuses to guess a strategy and aborts with *"Need to specify how to reconcile divergent branches"*. gitbasher caught the non-zero exit and surfaced the opaque `✗ Cannot pull current branch.` message.

## What changed

`scripts/merge.sh` and `scripts/rebase.sh` now delegate the pre-pull to the canonical `pull` function instead of running a bare `git pull`:

```bash
pull $current_branch $origin_name $editor
```

The `pull` function (the same one behind `gitb pull`) already does the right thing:
- **fast-forwards** when possible, otherwise
- **prompts** the user to choose **merge** or **rebase** to reconcile divergent branches (with an exit option).

This is an established, idiomatic pattern — `pull` is already called the same way elsewhere in the codebase (e.g. `pull $main_branch $origin_name $editor`).

## Notes
- Net effect is a simplification: ~42 lines of bespoke pull-output/stat handling removed in favor of the shared flow (10 insertions, 42 deletions).
- `bash -n` passes on both scripts and on the assembled `dist/gitb` bundle.
- CHANGELOG is auto-generated by semantic-release from the Conventional Commit, so it's intentionally not hand-edited.

https://claude.ai/code/session_01ReRCWXLxwnZfMJY4tZA8Hy

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReRCWXLxwnZfMJY4tZA8Hy)_