### PR TITLE
feat(branch): offer to push new branches to the remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,8 +464,8 @@ Notes:
 | `remote` | `re` `r` | Fetch and switch to a remote branch |
 | `main` | `def` `m` | Quick-switch to default branch |
 | `tag` | `t` | Checkout to a specific tag |
-| `new` | `n` `c` | Create branch from current |
-| `newd` | `nd` `cd` | Switch to main, pull, branch off |
+| `new` | `n` `c` | Create branch from current (offers to push it to the remote) |
+| `newd` | `nd` `cd` | Switch to main, pull, branch off (offers to push it to the remote) |
 | `delete` | `del` `d` | Delete branches (orphaned, merged, or selected) |
 | `prev` | `p` `-` | Switch to previous branch (`cd -`) |
 | `recent` | `rc` | Pick from recently checked-out branches |

--- a/scripts/branch.sh
+++ b/scripts/branch.sh
@@ -827,6 +827,19 @@ function branch_script {
             echo -e "${YELLOW}Moved changes:${ENDCOLOR}"
             echo -e "${changes}"
         fi
+
+        ### Offer to push the freshly created branch so it exists on the remote.
+        # The branch points at the same commit as its base for now, but pushing
+        # registers it on ${origin_name} (and sets up tracking with -u).
+        if [ -n "$origin_name" ]; then
+            echo
+            echo -e "Do you want to push the new branch to ${YELLOW}${origin_name}/${branch_name}${ENDCOLOR} (y/n)?"
+            yes_no_choice "Pushing..."
+
+            # push uses the current_branch global; we just switched onto branch_name.
+            current_branch="$branch_name"
+            push -u
+        fi
         exit
     fi
 

--- a/scripts/push.sh
+++ b/scripts/push.sh
@@ -161,7 +161,7 @@ function push_script {
         echo
         local PAD=16
         print_help_header $PAD
-        print_help_row $PAD "<empty>"  ""       "Show unpushed commits and push the current branch (pulls first if needed)"
+        print_help_row $PAD "<empty>"  ""       "Show unpushed commits and push the current branch (pulls first if needed); offers to create the branch on the remote if it isn't there yet"
         print_help_row $PAD "yes"      "y"      "Push without confirmation"
         print_help_row $PAD "force"    "f"      "Push with ${RED}--force-with-lease${ENDCOLOR} (overwrites remote unless someone else has pushed first)"
         print_help_row $PAD "list"     "log, l" "Show unpushed commits without pushing"
@@ -184,6 +184,24 @@ function push_script {
     get_push_list ${current_branch} ${main_branch} ${origin_name}
 
     if [ -z "$push_list" ]; then
+        ### A new branch with no commits ahead of its base still has nothing to
+        # "push" in the commit sense, but it doesn't exist on the remote yet.
+        # Offer to push it so the branch is created on ${origin_name}.
+        branch_on_remote=$(git rev-parse --verify --quiet "${origin_name}/${current_branch}" 2>/dev/null)
+        if [ -n "$origin_name" ] && [ -z "$branch_on_remote" ] && [ "${current_branch}" != "${main_branch}" ]; then
+            echo -e "${BLUE}Branch ${YELLOW}${current_branch}${BLUE} does not exist on ${YELLOW}${origin_name}${BLUE} yet.${ENDCOLOR}"
+            echo
+            if [ -z "${fast}" ]; then
+                echo -e "Do you want to push the new branch to ${YELLOW}${origin_name}/${current_branch}${ENDCOLOR} (y/n)?"
+                yes_no_choice "Pushing..."
+            else
+                echo -e "${YELLOW}Pushing...${ENDCOLOR}"
+                echo
+            fi
+            push -u
+            exit
+        fi
+
         echo -e "${GREEN}✓ Nothing to push${ENDCOLOR}"
         exit
     fi


### PR DESCRIPTION
## What

Adds two prompts so a newly created branch can be registered on the remote without an extra manual `git push`:

1. **After `gitb branch new` / `newd`** — once the branch is created (and any changes are carried over), gitbasher asks:
   > Do you want to push the new branch to `origin/<branch>` (y/n)?

   On yes it pushes with `-u` (sets up tracking) and reuses the existing `push` helper, so you get the same repo / branch / PR links and network-retry behavior.

2. **`gitb push` on a new branch with no commits** — previously a freshly branched-off branch with nothing ahead of its base printed `✓ Nothing to push` and exited, leaving the branch local-only. Now, if the branch doesn't exist on the remote yet (and isn't the default branch), it offers:
   > Branch `<branch>` does not exist on `origin` yet.
   > Do you want to push the new branch to `origin/<branch>` (y/n)?

   In fast mode (`gitb push y`) it pushes automatically without prompting.

## Behavior preserved

- On `main` (or any branch already on the remote) with nothing to push, it still prints `✓ Nothing to push`.
- Declining the prompt leaves the branch local-only.
- No prompt when there is no remote configured.

## Testing

Verified end-to-end against a temp repo with a bare remote:

- `gitb branch new` → prompt appears, `y` pushes the branch, `n` leaves it local.
- `gitb push` on a new no-commit branch → prompt appears and pushes; `gitb push y` auto-pushes.
- `gitb push` on `main` / an already-pushed branch → `Nothing to push`, no offer.

Updated `README.md` (branch mode table) and the `gitb push` help text. The pre-existing `column: command not found` test failures in this sandbox are environmental and unrelated to this change (they fail identically on `main`).

https://claude.ai/code/session_01AeNZDouVygLeEcAr2qed4z

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeNZDouVygLeEcAr2qed4z)_